### PR TITLE
Complete accounting bindings: subconto types from ПВХ, icons, deletion protection

### DIFF
--- a/src/engine/backend/metaCollection/partial/accountingRegisterMetadata.cpp
+++ b/src/engine/backend/metaCollection/partial/accountingRegisterMetadata.cpp
@@ -4,6 +4,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #include "accountingRegister.h"
+#include "chartOfAccounts.h"
 #include "list/objectList.h"
 #include "backend/metadataConfiguration.h"
 #include "backend/moduleManager/moduleManager.h"
@@ -177,6 +178,37 @@ bool ibValueMetaObjectAccountingRegister::OnAfterRunMetaObject(int flags)
 		(*m_propertyAttributeAccount)->ClearFlag(metaDisableFlag);
 	else
 		(*m_propertyAttributeAccount)->SetFlag(metaDisableFlag);
+
+	// Set Subconto1/2/3 types from ПВХ linked to the Chart of Accounts
+	// Find the Chart of Accounts and get its ПВХ binding
+	for (unsigned int idx = 0; idx < metaDesc.GetTypeCount(); idx++) {
+		const ibValueMetaObject* chartOfAccounts = m_metaData->FindAnyObjectByFilter(metaDesc.GetByIdx(idx));
+		if (chartOfAccounts != nullptr) {
+			// Cast to ibValueMetaObjectChartOfAccounts to access ПВХ binding
+			const ibValueMetaObjectChartOfAccounts* chartOfAccountsObj = nullptr;
+			if (chartOfAccounts->ConvertToValue(chartOfAccountsObj) && chartOfAccountsObj != nullptr) {
+				ibPropertyOwner* pvhBinding = chartOfAccountsObj->GetChartOfCharacteristicTypes();
+				if (pvhBinding != nullptr) {
+					const ibMetaDescription& pvhDesc = pvhBinding->GetValueAsMetaDesc();
+					ibTypeDescription subcontoTypeDesc;
+					for (unsigned int pvhIdx = 0; pvhIdx < pvhDesc.GetTypeCount(); pvhIdx++) {
+						const ibValueMetaObject* pvh = m_metaData->FindAnyObjectByFilter(pvhDesc.GetByIdx(pvhIdx));
+						if (pvh != nullptr) {
+							const ibCtorMetaValueType* pvhCtor = m_metaData->GetTypeCtor(pvh, ibCtorObjectMetaType::ibCtorObjectMetaType_Reference);
+							if (pvhCtor != nullptr)
+								subcontoTypeDesc.AppendMetaType(pvhCtor->GetClassType());
+						}
+					}
+					// Set all subconto fields to accept ПВХ reference types
+					if (subcontoTypeDesc.GetClsidCount() > 0) {
+						(*m_propertyAttributeSubconto1)->SetDefaultMetaType(subcontoTypeDesc);
+						(*m_propertyAttributeSubconto2)->SetDefaultMetaType(subcontoTypeDesc);
+						(*m_propertyAttributeSubconto3)->SetDefaultMetaType(subcontoTypeDesc);
+					}
+				}
+			}
+		}
+	}
 
 	if (appData->DesignerMode()) {
 		if (ibValueMetaObjectRegisterData::OnAfterRunMetaObject(flags)) {

--- a/src/engine/backend/metaCollection/partial/chartOfAccountsMetadata.cpp
+++ b/src/engine/backend/metaCollection/partial/chartOfAccountsMetadata.cpp
@@ -249,8 +249,31 @@ bool ibValueMetaObjectChartOfAccounts::OnAfterRunMetaObject(int flags)
 {
 	if (!(*m_propertyModuleObject)->OnAfterRunMetaObject(flags)) return false;
 	if (!(*m_propertyModuleManager)->OnAfterRunMetaObject(flags)) return false;
+
 	ibValueModuleManager* moduleManager = m_metaData->GetModuleManager();
 	wxASSERT(moduleManager);
+
+	// Set SubcontoKind column type from ПВХ binding
+	const ibMetaDescription& metaDesc = m_propertyChartOfCharacteristicTypes->GetValueAsMetaDesc();
+	if (m_subcontoKindsTable != nullptr && metaDesc.GetTypeCount() > 0) {
+		ibTypeDescription typeDesc;
+		for (unsigned int idx = 0; idx < metaDesc.GetTypeCount(); idx++) {
+			const ibValueMetaObject* chartOfCharTypes = m_metaData->FindAnyObjectByFilter(metaDesc.GetByIdx(idx));
+			if (chartOfCharTypes != nullptr) {
+				const ibCtorMetaValueType* so = m_metaData->GetTypeCtor(chartOfCharTypes, ibCtorObjectMetaType::ibCtorObjectMetaType_Reference);
+				wxASSERT(so);
+				typeDesc.AppendMetaType(so->GetClassType());
+			}
+		}
+		// Update SubcontoKind column type in predefined table
+		ibValueMetaObjectAttributeBase* kindAttr = m_subcontoKindsTable->FindAnyAttributeObjectByFilter(wxT("SubcontoKind"));
+		if (kindAttr != nullptr) {
+			kindAttr->GetTypeDesc().SetDefaultMetaType(typeDesc);
+		}
+		// Prevent deletion of predefined tabular section
+		m_subcontoKindsTable->SetFlag(metaDisableFlag);
+	}
+
 	if (appData->DesignerMode()) {
 		if (ibValueMetaObjectRecordDataHierarchyMutableRef::OnAfterRunMetaObject(flags))
 			return moduleManager->AddCompileModule(m_propertyModuleObject->GetMetaObject(), CreateObjectValue(ibObjectMode::OBJECT_ITEM));

--- a/src/engine/backend/metaCollection/partial/chartOfAccountsMetadata_res.cpp
+++ b/src/engine/backend/metaCollection/partial/chartOfAccountsMetadata_res.cpp
@@ -1,7 +1,7 @@
 #include "chartOfAccounts.h"
 
-/* PNG - chart of accounts icon 16x16 (uses document icon) */
-static const wxString s_chartOfAccounts_16_png = wxT("iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAA3NCSVQICAjb4U/gAAAAIVBMVEUAAAF4i5x9j5////+Mnat9kJ/29/iOnaz09veLm6l9j6C1uLjiAAAAAXRSTlMAQObYZgAAADhJREFUGJVjYGCEAyYGMGBkhgJGFlY0ATZ2JlQBZg5OLiQBiDnIKsCiuAQgygmpoNQMVAEUwIABAB6/AfGpRQdOAAAAAElFTkSuQmCC");
+/* PNG - chart of accounts icon 16x16 (dimension-style, orange) */
+static const wxString s_chartOfAccounts_16_png = wxT("iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAA3NCSVQICAjb4U/gAAAACVBMVEUAAAH9s4D/38FifTNXAAAAAXRSTlMAQObYZgAAABlJREFUGJVjYKAFYEQDDIxMKIA8AXRDaQEAUdAAmeJBSsoAAAAASUVORK5CYII=");
 
 wxIcon ibValueMetaObjectChartOfAccounts::GetIcon() const
 {

--- a/src/engine/backend/metaCollection/partial/chartOfCharacteristicTypesMetadata_res.cpp
+++ b/src/engine/backend/metaCollection/partial/chartOfCharacteristicTypesMetadata_res.cpp
@@ -1,7 +1,7 @@
 #include "chartOfCharacteristicTypes.h"
 
-/* PNG - chart of characteristic types icon 16x16 (uses constant icon) */
-static const wxString s_chartOfCharacteristicTypes_16_png = wxT("iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAA3NCSVQICAjb4U/gAAAACVBMVEUAAAF4i5z/9e36LQ2XAAAAAXRSTlMAQObYZgAAABlJREFUGJVjYKAFYEQDDIxMKIA8AXRDaQEAUdAAmeJBSsoAAAAASUVORK5CYII=");
+/* PNG - chart of characteristic types icon 16x16 (attribute-style, blue) */
+static const wxString s_chartOfCharacteristicTypes_16_png = wxT("iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAA3NCSVQICAjb4U/gAAAACVBMVEUAAAF0lsTb8v+YmrAhAAAAAXRSTlMAQObYZgAAABlJREFUGJVjYKAFYEQDDIxMKIA8AXRDaQEAUdAAmeJBSsoAAAAASUVORK5CYII=");
 
 wxIcon ibValueMetaObjectChartOfCharacteristicTypes::GetIcon() const
 {


### PR DESCRIPTION
## Summary

Final accounting bindings completing the Chart of Accounts implementation.

### Changes

- **ChartOfAccounts OnAfterRunMetaObject**: set SubcontoKind column type from linked ПВХ (ibTypeDescription), protect predefined SubcontoKinds tabular section from deletion (metaDisableFlag)
- **AccountingRegister OnAfterRunMetaObject**: set Subconto1/2/3 field types from ПВХ linked to the bound Chart of Accounts — full chain: Register → ChartOfAccounts → ПВХ → subconto types
- **Icons**: ПВХ uses attribute-style (blue), ChartOfAccounts uses dimension-style (orange) — visually distinct

### Binding chain

```
AccountingRegister.OnAfterRunMetaObject()
  → reads ChartOfAccounts binding
  → finds linked ПВХ from ChartOfAccounts
  → sets Subconto1/2/3 types = ПВХ reference type

ChartOfAccounts.OnAfterRunMetaObject()
  → reads ПВХ binding
  → sets SubcontoKind column type in predefined ТЧ = ПВХ reference type
  → sets metaDisableFlag on SubcontoKinds ТЧ (prevent deletion)
```

## Test plan

- [ ] Verify SubcontoKind column accepts only elements from linked ПВХ
- [ ] Verify Subconto1/2/3 in accounting register accept ПВХ reference types
- [ ] Verify SubcontoKinds ТЧ cannot be deleted from designer
- [ ] Verify ПВХ icon is blue, ChartOfAccounts icon is orange