### PR TITLE
Fix: register SubcontoKindsTable in type factory (MD_SKTB)

### DIFF
--- a/src/engine/backend/metaCollection/partial/chartOfAccountsSubcontoTable.cpp
+++ b/src/engine/backend/metaCollection/partial/chartOfAccountsSubcontoTable.cpp
@@ -79,3 +79,11 @@ bool ibValueMetaObjectSubcontoKindsTable::OnAfterCloseMetaObject()
 	if (!(*m_propertySummaryOnly)->OnAfterCloseMetaObject()) return false;
 	return ibValueMetaObjectTableData::OnAfterCloseMetaObject();
 }
+
+//***********************************************************************
+//*                       Register in runtime                           *
+//***********************************************************************
+
+const ibClassID g_metaSubcontoKindsTableCLSID = string_to_clsid("MD_SKTB");
+
+METADATA_TYPE_REGISTER(ibValueMetaObjectSubcontoKindsTable, "SubcontoKindsTable", g_metaSubcontoKindsTableCLSID);


### PR DESCRIPTION
Fixes assert 'typeCtor failed in GetTypeIDByRef' in valueFactory.cpp(138). Every inherited metadata class must have METADATA_TYPE_REGISTER.