### PR TITLE
Fix: revert ПВХ/ChartOfAccounts from catalog Owner dialog

### DIFF
--- a/src/engine/frontend/propertyManager/property/advprop/advpropOwner.cpp
+++ b/src/engine/frontend/propertyManager/property/advprop/advpropOwner.cpp
@@ -41,8 +41,6 @@ ibPGOwnerProperty::ibPGOwnerProperty(const ibPropertyObject* property, const wxS
 	: wxPGProperty(label, strName), m_ownerProperty(property)
 {
 	FillByClsid(g_metaCatalogCLSID);
-	FillByClsid(g_metaChartOfCharacteristicTypesCLSID);
-	FillByClsid(g_metaChartOfAccountsCLSID);
 
 	//m_flags |= wxPGFlags::ReadOnly;
 	m_flags |= wxPGPropertyFlags_ActiveButton; // Property button always enabled.
@@ -178,8 +176,6 @@ wxPGEditorDialogAdapter* ibPGOwnerProperty::GetEditorDialog() const
 			wxASSERT(metaData);
 			if (metaData != nullptr) {
 				FillByClsid(metaData, g_metaCatalogCLSID, tc, data);
-				FillByClsid(metaData, g_metaChartOfCharacteristicTypesCLSID, tc, data);
-				FillByClsid(metaData, g_metaChartOfAccountsCLSID, tc, data);
 			}
 
 			tc->ExpandAll(); int res = dlg->ShowModal();


### PR DESCRIPTION
ibPropertyOwner is for Catalog Owner — should only show Catalogs. ПВХ and ChartOfAccounts were incorrectly added in PR#52, causing them to appear in catalog owner selection. They need separate property types.