### PR TITLE
Add separate property selectors for ПВХ and Chart of Accounts

### DIFF
--- a/src/engine/backend/metaCollection/partial/accountingRegister.h
+++ b/src/engine/backend/metaCollection/partial/accountingRegister.h
@@ -3,7 +3,7 @@
 
 #include "commonObject.h"
 #include "accountingRegisterEnum.h"
-#include "backend/propertyManager/property/propertyOwner.h"
+#include "backend/propertyManager/property/propertyChartOfAccounts.h"
 
 class ibValueMetaObjectAccountingRegister : public ibValueMetaObjectRegisterData {
 	wxDECLARE_DYNAMIC_CLASS(ibValueMetaObjectAccountingRegister);
@@ -187,7 +187,7 @@ private:
 	/////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// Chart of Accounts binding — determines the type of Account field
 	ibPropertyCategory* m_categoryData = ibPropertyObject::CreatePropertyCategory(wxT("Data"), _("Data"));
-	ibPropertyOwner* m_propertyChartOfAccounts = ibPropertyObject::CreateProperty<ibPropertyOwner>(m_categoryData, wxT("ChartOfAccounts"), _("Chart of accounts"));
+	ibPropertyChartOfAccounts* m_propertyChartOfAccounts = ibPropertyObject::CreateProperty<ibPropertyChartOfAccounts>(m_categoryData, wxT("ChartOfAccounts"), _("Chart of accounts"));
 
 	// Predefined attributes: RecordType (Debit/Credit)
 	ibPropertyInnerAttribute<>* m_propertyAttributeRecordType = ibPropertyObject::CreateProperty<ibPropertyInnerAttribute<>>(m_categoryCommon,

--- a/src/engine/backend/metaCollection/partial/accountingRegisterMetadata.cpp
+++ b/src/engine/backend/metaCollection/partial/accountingRegisterMetadata.cpp
@@ -187,7 +187,7 @@ bool ibValueMetaObjectAccountingRegister::OnAfterRunMetaObject(int flags)
 			// Cast to ibValueMetaObjectChartOfAccounts to access ПВХ binding
 			const ibValueMetaObjectChartOfAccounts* chartOfAccountsObj = nullptr;
 			if (chartOfAccounts->ConvertToValue(chartOfAccountsObj) && chartOfAccountsObj != nullptr) {
-				ibPropertyOwner* pvhBinding = chartOfAccountsObj->GetChartOfCharacteristicTypes();
+				ibPropertyChartOfCharacteristicTypes* pvhBinding = chartOfAccountsObj->GetChartOfCharacteristicTypes();
 				if (pvhBinding != nullptr) {
 					const ibMetaDescription& pvhDesc = pvhBinding->GetValueAsMetaDesc();
 					ibTypeDescription subcontoTypeDesc;

--- a/src/engine/backend/metaCollection/partial/chartOfAccounts.h
+++ b/src/engine/backend/metaCollection/partial/chartOfAccounts.h
@@ -5,7 +5,7 @@
 #include "reference/reference.h"
 #include "chartOfAccountsEnum.h"
 #include "chartOfAccountsSubcontoTable.h"
-#include "backend/propertyManager/property/propertyOwner.h"
+#include "backend/propertyManager/property/propertyChartOfCharacteristicTypes.h"
 
 //********************************************************************************************
 //*                                  Factory & metaData                                      *
@@ -50,7 +50,7 @@ public:
 	ibValueMetaObjectAttributePredefined* GetMaxSubcontoCount() const { return m_propertyAttributeMaxSubcontoCount->GetMetaObject(); }
 
 	// Chart of Characteristic Types binding (determines available subconto types)
-	ibPropertyOwner* GetChartOfCharacteristicTypes() const { return m_propertyChartOfCharacteristicTypes; }
+	ibPropertyChartOfCharacteristicTypes* GetChartOfCharacteristicTypes() const { return m_propertyChartOfCharacteristicTypes; }
 
 	//default constructor
 	ibValueMetaObjectChartOfAccounts();
@@ -244,7 +244,7 @@ private:
 	/////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// Chart of Characteristic Types binding (determines subconto types available for this chart of accounts)
 	ibPropertyCategory* m_categoryData = ibPropertyObject::CreatePropertyCategory(wxT("Data"), _("Data"));
-	ibPropertyOwner* m_propertyChartOfCharacteristicTypes = ibPropertyObject::CreateProperty<ibPropertyOwner>(m_categoryData, wxT("ChartOfCharacteristicTypes"), _("Chart of characteristic types"));
+	ibPropertyChartOfCharacteristicTypes* m_propertyChartOfCharacteristicTypes = ibPropertyObject::CreateProperty<ibPropertyChartOfCharacteristicTypes>(m_categoryData, wxT("ChartOfCharacteristicTypes"), _("Chart of characteristic types"));
 
 	/////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// Predefined tabular section "SubcontoKinds" — own meta class with predefined columns

--- a/src/engine/backend/metaCollection/partial/chartOfAccountsMetadata.cpp
+++ b/src/engine/backend/metaCollection/partial/chartOfAccountsMetadata.cpp
@@ -241,8 +241,7 @@ bool ibValueMetaObjectChartOfAccounts::OnAfterRunMetaObject(int flags)
 
 	// Set SubcontoKind column type from ПВХ binding
 	const ibMetaDescription& metaDesc = m_propertyChartOfCharacteristicTypes->GetValueAsMetaDesc();
-	ibValueMetaObjectSubcontoKindsTable* subcontoKindsTable = m_propertySubcontoKindsTable->GetMetaObject();
-	if (subcontoKindsTable != nullptr && metaDesc.GetTypeCount() > 0) {
+	if (m_subcontoKindsTable != nullptr && metaDesc.GetTypeCount() > 0) {
 		ibTypeDescription typeDesc;
 		for (unsigned int idx = 0; idx < metaDesc.GetTypeCount(); idx++) {
 			const ibValueMetaObject* chartOfCharTypes = m_metaData->FindAnyObjectByFilter(metaDesc.GetByIdx(idx));
@@ -253,12 +252,12 @@ bool ibValueMetaObjectChartOfAccounts::OnAfterRunMetaObject(int flags)
 			}
 		}
 		// Update SubcontoKind column type in predefined table
-		ibValueMetaObjectAttributeBase* kindAttr = subcontoKindsTable->GetSubcontoKind();
+		ibValueMetaObjectAttributeBase* kindAttr = m_subcontoKindsTable->GetSubcontoKind();
 		if (kindAttr != nullptr) {
 			kindAttr->GetTypeDesc().SetDefaultMetaType(typeDesc);
 		}
 		// Prevent deletion of predefined tabular section
-		subcontoKindsTable->SetFlag(metaDisableFlag);
+		m_subcontoKindsTable->SetFlag(metaDisableFlag);
 	}
 
 	if (appData->DesignerMode()) {

--- a/src/engine/backend/propertyManager/property/propertyChartOfAccounts.cpp
+++ b/src/engine/backend/propertyManager/property/propertyChartOfAccounts.cpp
@@ -1,0 +1,40 @@
+#include "propertyChartOfAccounts.h"
+#include "backend/propertyManager/property/variant/variantOwner.h"
+
+wxObject* (*ibPropertyChartOfAccounts::ms_propertyChartOfAccounts)(ibPropertyObject*, const wxString&, const wxString&, const wxVariant&) = nullptr;
+
+wxVariantData* ibPropertyChartOfAccounts::CreateVariantData(ibPropertyObject* property, const ibMetaDescription& typeDesc) const
+{
+	const ibValueMetaObjectGenericData* propFactory = dynamic_cast<const ibValueMetaObjectGenericData*>(property);
+	if (propFactory == nullptr) return nullptr;
+	return new ibVariantDataOwner(propFactory, typeDesc);
+}
+
+ibMetaDescription& ibPropertyChartOfAccounts::GetValueAsMetaDesc() const {
+	return get_cell_variant<ibVariantDataOwner>()->GetMetaDesc();
+}
+
+void ibPropertyChartOfAccounts::SetValue(const ibMetaDescription& val)
+{
+	m_propValue = CreateVariantData(m_owner, val);
+}
+
+bool ibPropertyChartOfAccounts::SetDataValue(const ibValue& varPropVal) { return false; }
+
+bool ibPropertyChartOfAccounts::GetDataValue(ibValue& pvarPropVal) const
+{
+	const ibVariantDataOwner* owner = get_cell_variant<ibVariantDataOwner>();
+	wxASSERT(owner);
+	pvarPropVal = owner->GetDataValue();
+	return true;
+}
+
+bool ibPropertyChartOfAccounts::LoadData(ibReaderMemory& reader)
+{
+	return ibMetaDescriptionMemory::LoadData(reader, GetValueAsMetaDesc());
+}
+
+bool ibPropertyChartOfAccounts::SaveData(ibWriterMemory& writer)
+{
+	return ibMetaDescriptionMemory::SaveData(writer, GetValueAsMetaDesc());
+}

--- a/src/engine/backend/propertyManager/property/propertyChartOfAccounts.h
+++ b/src/engine/backend/propertyManager/property/propertyChartOfAccounts.h
@@ -1,0 +1,39 @@
+#ifndef __PROPERTY_CHART_OF_ACCOUNTS_H__
+#define __PROPERTY_CHART_OF_ACCOUNTS_H__
+
+#include "backend/propertyManager/propertyObject.h"
+#include "backend/backend_type.h"
+
+//base property for "chart of accounts" selection
+class BACKEND_API ibPropertyChartOfAccounts : public ibProperty {
+	wxVariantData* CreateVariantData(ibPropertyObject* property, const ibMetaDescription& typeDesc = ibMetaDescription()) const;
+public:
+
+	ibMetaDescription& GetValueAsMetaDesc() const;
+	void SetValue(const ibMetaDescription& val);
+
+	ibPropertyChartOfAccounts(ibPropertyCategory* cat, const wxString& name) : ibProperty(cat, name, CreateVariantData(cat->GetPropertyObject())) {}
+	ibPropertyChartOfAccounts(ibPropertyCategory* cat, const wxString& name, const wxString& label) : ibProperty(cat, name, label, CreateVariantData(cat->GetPropertyObject())) {}
+	ibPropertyChartOfAccounts(ibPropertyCategory* cat, const wxString& name, const wxString& label, const wxString& helpString) : ibProperty(cat, name, label, helpString, CreateVariantData(cat->GetPropertyObject())) {}
+
+	//get property for grid
+	virtual wxObject* GetPGProperty() const {
+		if (ms_propertyChartOfAccounts != nullptr)
+			return ms_propertyChartOfAccounts(m_owner, m_propLabel, m_propName, m_propValue);
+		return nullptr;
+	}
+
+	// set/get property data
+	virtual bool SetDataValue(const ibValue& varPropVal);
+	virtual bool GetDataValue(ibValue& pvarPropVal) const;
+
+	//load & save object in control
+	virtual bool LoadData(ibReaderMemory& reader);
+	virtual bool SaveData(ibWriterMemory& writer);
+
+public:
+
+	static wxObject* (*ms_propertyChartOfAccounts)(ibPropertyObject*, const wxString&, const wxString&, const wxVariant&);
+};
+
+#endif

--- a/src/engine/backend/propertyManager/property/propertyChartOfCharacteristicTypes.cpp
+++ b/src/engine/backend/propertyManager/property/propertyChartOfCharacteristicTypes.cpp
@@ -1,0 +1,40 @@
+#include "propertyChartOfCharacteristicTypes.h"
+#include "backend/propertyManager/property/variant/variantOwner.h"
+
+wxObject* (*ibPropertyChartOfCharacteristicTypes::ms_propertyChartOfCharacteristicTypes)(ibPropertyObject*, const wxString&, const wxString&, const wxVariant&) = nullptr;
+
+wxVariantData* ibPropertyChartOfCharacteristicTypes::CreateVariantData(ibPropertyObject* property, const ibMetaDescription& typeDesc) const
+{
+	const ibValueMetaObjectGenericData* propFactory = dynamic_cast<const ibValueMetaObjectGenericData*>(property);
+	if (propFactory == nullptr) return nullptr;
+	return new ibVariantDataOwner(propFactory, typeDesc);
+}
+
+ibMetaDescription& ibPropertyChartOfCharacteristicTypes::GetValueAsMetaDesc() const {
+	return get_cell_variant<ibVariantDataOwner>()->GetMetaDesc();
+}
+
+void ibPropertyChartOfCharacteristicTypes::SetValue(const ibMetaDescription& val)
+{
+	m_propValue = CreateVariantData(m_owner, val);
+}
+
+bool ibPropertyChartOfCharacteristicTypes::SetDataValue(const ibValue& varPropVal) { return false; }
+
+bool ibPropertyChartOfCharacteristicTypes::GetDataValue(ibValue& pvarPropVal) const
+{
+	const ibVariantDataOwner* owner = get_cell_variant<ibVariantDataOwner>();
+	wxASSERT(owner);
+	pvarPropVal = owner->GetDataValue();
+	return true;
+}
+
+bool ibPropertyChartOfCharacteristicTypes::LoadData(ibReaderMemory& reader)
+{
+	return ibMetaDescriptionMemory::LoadData(reader, GetValueAsMetaDesc());
+}
+
+bool ibPropertyChartOfCharacteristicTypes::SaveData(ibWriterMemory& writer)
+{
+	return ibMetaDescriptionMemory::SaveData(writer, GetValueAsMetaDesc());
+}

--- a/src/engine/backend/propertyManager/property/propertyChartOfCharacteristicTypes.h
+++ b/src/engine/backend/propertyManager/property/propertyChartOfCharacteristicTypes.h
@@ -1,0 +1,39 @@
+#ifndef __PROPERTY_CHART_OF_CHARACTERISTIC_TYPES_H__
+#define __PROPERTY_CHART_OF_CHARACTERISTIC_TYPES_H__
+
+#include "backend/propertyManager/propertyObject.h"
+#include "backend/backend_type.h"
+
+//base property for "chart of characteristic types" selection
+class BACKEND_API ibPropertyChartOfCharacteristicTypes : public ibProperty {
+	wxVariantData* CreateVariantData(ibPropertyObject* property, const ibMetaDescription& typeDesc = ibMetaDescription()) const;
+public:
+
+	ibMetaDescription& GetValueAsMetaDesc() const;
+	void SetValue(const ibMetaDescription& val);
+
+	ibPropertyChartOfCharacteristicTypes(ibPropertyCategory* cat, const wxString& name) : ibProperty(cat, name, CreateVariantData(cat->GetPropertyObject())) {}
+	ibPropertyChartOfCharacteristicTypes(ibPropertyCategory* cat, const wxString& name, const wxString& label) : ibProperty(cat, name, label, CreateVariantData(cat->GetPropertyObject())) {}
+	ibPropertyChartOfCharacteristicTypes(ibPropertyCategory* cat, const wxString& name, const wxString& label, const wxString& helpString) : ibProperty(cat, name, label, helpString, CreateVariantData(cat->GetPropertyObject())) {}
+
+	//get property for grid
+	virtual wxObject* GetPGProperty() const {
+		if (ms_propertyChartOfCharacteristicTypes != nullptr)
+			return ms_propertyChartOfCharacteristicTypes(m_owner, m_propLabel, m_propName, m_propValue);
+		return nullptr;
+	}
+
+	// set/get property data
+	virtual bool SetDataValue(const ibValue& varPropVal);
+	virtual bool GetDataValue(ibValue& pvarPropVal) const;
+
+	//load & save object in control
+	virtual bool LoadData(ibReaderMemory& reader);
+	virtual bool SaveData(ibWriterMemory& writer);
+
+public:
+
+	static wxObject* (*ms_propertyChartOfCharacteristicTypes)(ibPropertyObject*, const wxString&, const wxString&, const wxVariant&);
+};
+
+#endif

--- a/src/engine/frontend/propertyManager/property/advprop/advpropChartOfAccounts.cpp
+++ b/src/engine/frontend/propertyManager/property/advprop/advpropChartOfAccounts.cpp
@@ -1,0 +1,208 @@
+#include "advpropChartOfAccounts.h"
+
+#include "backend/propertyManager/property/variant/variantOwner.h"
+#include "backend/propertyManager/property/propertyChartOfAccounts.h"
+
+#include "frontend/propertyManager/property/private/prop.h"
+#include "frontend/propertyManager/propertyEditor.h"
+
+#define icon_size 16
+
+// -----------------------------------------------------------------------
+// ibPGChartOfAccountsProperty
+// -----------------------------------------------------------------------
+
+wxPG_IMPLEMENT_PROPERTY_CLASS(ibPGChartOfAccountsProperty, wxPGProperty, ComboBoxAndButton)
+
+// register frontend property
+class ibPropertyChartOfAccountsLoader
+{
+public:
+	ibPropertyChartOfAccountsLoader()
+	{
+		ibPG_IMPLEMENT_PROPERTY_CALLBACK(ibPGChartOfAccountsProperty, ibPropertyChartOfAccounts::ms_propertyChartOfAccounts);
+	}
+}g_chartOfAccountsLoader;
+
+#include "backend/metadata.h"
+
+void ibPGChartOfAccountsProperty::FillByClsid(const ibClassID& clsid)
+{
+	const ibValueMetaObjectGenericData* metaGenericData = dynamic_cast<const ibValueMetaObjectGenericData*>(m_ownerProperty);
+	if (metaGenericData != nullptr) {
+		const ibMetaData* metaData = metaGenericData->GetMetaData();
+		wxASSERT(metaData);
+		for (auto metaOwner : metaData->GetAnyArrayObject(clsid)) {
+			m_choices.Add(metaOwner->GetName(), metaOwner->GetIcon(), metaOwner->GetMetaID());
+		}
+	}
+}
+
+ibPGChartOfAccountsProperty::ibPGChartOfAccountsProperty(const ibPropertyObject* property, const wxString& label, const wxString& strName, const wxVariant& value)
+	: wxPGProperty(label, strName), m_ownerProperty(property)
+{
+	FillByClsid(g_metaChartOfAccountsCLSID);
+
+	//m_flags |= wxPGFlags::ReadOnly;
+	m_flags |= wxPGPropertyFlags_ActiveButton; // Property button always enabled.
+
+	SetValue(value);
+}
+
+wxString ibPGChartOfAccountsProperty::ValueToString( wxVariant& value, wxPGPropValFormatFlags flags ) const
+{
+	return value.GetString();
+}
+
+bool ibPGChartOfAccountsProperty::StringToValue(wxVariant& variant,
+	const wxString& text,
+	wxPGPropValFormatFlags flags) const
+{
+	return false;
+}
+
+bool ibPGChartOfAccountsProperty::IntToValue(wxVariant& value, int number, wxPGPropValFormatFlags flags) const
+{
+	ibVariantDataOwner* dataOwner = property_cast(value, ibVariantDataOwner);
+	if (dataOwner != nullptr) {
+		ibVariantDataOwner* newDataOwner = dataOwner->Clone();
+		wxASSERT(newDataOwner);
+		ibMetaDescription& md = newDataOwner->GetMetaDesc();
+		md.SetDefaultMetaType(m_choices.GetValue(number));
+		value = newDataOwner;
+		return true;
+	}
+	return false;
+}
+
+#include "frontend/win/ctrls/checktree.h"
+
+wxPGEditorDialogAdapter* ibPGChartOfAccountsProperty::GetEditorDialog() const
+{
+	class ibPGEditorChartOfAccountsDialogAdapter : public wxPGEditorDialogAdapter {
+
+		class ibTreeItemPropertyData : public wxTreeItemData {
+			ibValueMetaObject* m_metaObject;
+		public:
+			ibTreeItemPropertyData(ibValueMetaObject* opt) : wxTreeItemData(), m_metaObject(opt) {}
+			ibMetaID GetMetaID() const { return m_metaObject->GetMetaID(); }
+		};
+
+		void FillByClsid(ibMetaData* metaData, const ibClassID& clsid,
+			ibCheckTree* tc, ibVariantDataOwner* data) {
+
+			wxImageList* imageList = tc->GetImageList();
+			wxASSERT(imageList);
+			const ibCtorAbstractType* so = ibValue::GetAvailableCtor(clsid);
+			int groupIcon = imageList->Add(so->GetClassIcon());
+			const wxTreeItemId& parentID = tc->AppendItem(tc->GetRootItem(), so->GetClassName(),
+				groupIcon, groupIcon);
+			for (auto metaObject : metaData->GetAnyArrayObject(clsid)) {
+				ibValueMetaObjectRecordDataRef* registerData = dynamic_cast<ibValueMetaObjectRecordDataRef*>(metaObject);
+				if (registerData != nullptr) {
+					{
+						int icon = imageList->Add(registerData->GetIcon());
+						ibTreeItemPropertyData* itemData = new ibTreeItemPropertyData(metaObject);
+						wxTreeItemId newItem = tc->AppendItem(parentID, registerData->GetName(),
+							icon, icon,
+							itemData);
+
+						if (data != nullptr) {
+							const ibMetaDescription& md = data->GetMetaDesc();
+							tc->SetItemState(newItem, md.ContainMetaType(registerData->GetMetaID()) ? ibCheckTree::CHECKED : ibCheckTree::UNCHECKED);
+							tc->Check(newItem, md.ContainMetaType(registerData->GetMetaID()));
+						}
+						else {
+							tc->SetItemState(newItem, ibCheckTree::UNCHECKED);
+							tc->Check(newItem, false);
+						}
+					}
+				}
+			}
+		}
+
+	public:
+
+		virtual bool DoShowDialog(wxPropertyGrid* pg, wxPGProperty* prop) wxOVERRIDE
+		{
+			ibPGChartOfAccountsProperty* dlgProp = wxDynamicCast(prop, ibPGChartOfAccountsProperty);
+			wxCHECK_MSG(dlgProp, false, "Function called for incompatible property");
+
+			ibVariantDataOwner* data = property_cast(dlgProp->GetValue(), ibVariantDataOwner);
+			if (data == nullptr) return false;
+			const ibValueMetaObjectGenericData* metaGenericData = dynamic_cast<const ibValueMetaObjectGenericData*>(dlgProp->GetPropertyObject());
+			if (metaGenericData == nullptr) return false;
+
+			// launch editor dialog
+			wxDialog* dlg = new wxDialog(pg, wxID_ANY, _("Choice chart of accounts"), wxDefaultPosition, wxDefaultSize,
+				wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxCLIP_CHILDREN);
+
+			dlg->SetFont(pg->GetFont()); // To allow entering chars of the same set as the propGrid
+
+			// Multi-line text editor dialog.
+			const int spacing = wxPropertyGrid::IsSmallScreen() ? 4 : 8;
+			wxBoxSizer* topsizer = new wxBoxSizer(wxVERTICAL);
+			wxBoxSizer* rowsizer = new wxBoxSizer(wxHORIZONTAL);
+
+			ibCheckTree* tc = new ibCheckTree(dlg, wxID_ANY,
+				wxDefaultPosition, wxDefaultSize, wxTR_HAS_BUTTONS | wxTR_LINES_AT_ROOT | wxTR_NO_LINES | wxTR_HIDE_ROOT | wxCR_MULTIPLE_CHECK | wxCR_EMPTY_CHECK | wxSUNKEN_BORDER | wxTR_TWIST_BUTTONS);
+
+			wxTreeItemId rootItem = tc->AddRoot(wxEmptyString);
+
+			rowsizer->Add(tc, wxSizerFlags(1).Expand().Border(wxALL, spacing));
+			topsizer->Add(rowsizer, wxSizerFlags(1).Expand());
+
+			tc->SetDoubleBuffered(true);
+			tc->Enable(!dlgProp->HasFlag(wxPGFlags::ReadOnly));
+
+			wxStdDialogButtonSizer* buttonSizer = dlg->CreateStdDialogButtonSizer(wxOK | wxCANCEL);
+			topsizer->Add(buttonSizer, wxSizerFlags(0).Right().Border(wxBOTTOM | wxRIGHT, spacing));
+
+			dlg->SetSizer(topsizer);
+			topsizer->SetSizeHints(dlg);
+
+			if (!wxPropertyGrid::IsSmallScreen()) {
+				dlg->SetSize(400, 300);
+				dlg->Move(pg->GetGoodEditorDialogPosition(prop, dlg->GetSize()));
+			}
+
+			tc->SetFocus();
+
+			// Make an state image list containing small icons
+			tc->AssignImageList(
+				new wxImageList(icon_size, icon_size)
+			);
+
+			ibMetaData* metaData = metaGenericData->GetMetaData();
+			wxASSERT(metaData);
+			if (metaData != nullptr) {
+				FillByClsid(metaData, g_metaChartOfAccountsCLSID, tc, data);
+			}
+
+			tc->ExpandAll(); int res = dlg->ShowModal();
+
+			ibVariantDataOwner* clone = data->Clone();
+			{
+				ibMetaDescription& metaDesc = clone->GetMetaDesc(); metaDesc.ClearMetaType();
+				wxArrayTreeItemIds ids;
+				unsigned int selCount = tc->GetSelections(ids);
+				for (const wxTreeItemId& selItem : ids) {
+					if (selItem.IsOk()) {
+						wxTreeItemData* dataItem = tc->GetItemData(selItem);
+						if (dataItem && res == wxID_OK) {
+							ibTreeItemPropertyData* item = dynamic_cast<ibTreeItemPropertyData*>(dataItem);
+							wxASSERT(item);
+							metaDesc.AppendMetaType(item->GetMetaID());
+						}
+					}
+				}
+			}
+			SetValue(clone);
+
+			dlg->Destroy();
+			return res == wxID_OK;
+		}
+	};
+
+	return new ibPGEditorChartOfAccountsDialogAdapter();
+}

--- a/src/engine/frontend/propertyManager/property/advprop/advpropChartOfAccounts.h
+++ b/src/engine/frontend/propertyManager/property/advprop/advpropChartOfAccounts.h
@@ -1,0 +1,41 @@
+#ifndef __ADVPROP_CHART_OF_ACCOUNTS_H__
+#define __ADVPROP_CHART_OF_ACCOUNTS_H__
+
+#include <wx/propgrid/propgrid.h>
+#include "backend/backend_type.h"
+
+class BACKEND_API ibPropertyObject;
+
+// -----------------------------------------------------------------------
+// ibPGChartOfAccountsProperty
+// -----------------------------------------------------------------------
+
+class ibPGChartOfAccountsProperty : public wxPGProperty {
+	void FillByClsid(const ibClassID& clsid);
+public:
+
+	const ibPropertyObject* GetPropertyObject() const { return m_ownerProperty; }
+
+	ibPGChartOfAccountsProperty(const ibPropertyObject* property = nullptr, const wxString& label = wxPG_LABEL,
+		const wxString& name = wxPG_LABEL, const wxVariant& value = wxNullVariant);
+
+	virtual wxString ValueToString(wxVariant& value,
+		wxPGPropValFormatFlags flags = wxPGPropValFormatFlags::Null) const override;
+
+	virtual bool StringToValue(wxVariant& variant,
+		const wxString& text,
+		wxPGPropValFormatFlags flags = wxPGPropValFormatFlags::Null) const override;
+
+	virtual bool IntToValue(wxVariant& value,
+		int number,
+		wxPGPropValFormatFlags flags = wxPGPropValFormatFlags::Null) const override;
+
+	virtual wxPGEditorDialogAdapter* GetEditorDialog() const override;
+
+protected:
+	const ibPropertyObject* m_ownerProperty = nullptr;
+private:
+	WX_PG_DECLARE_PROPERTY_CLASS(ibPGChartOfAccountsProperty);
+};
+
+#endif

--- a/src/engine/frontend/propertyManager/property/advprop/advpropChartOfCharacteristicTypes.cpp
+++ b/src/engine/frontend/propertyManager/property/advprop/advpropChartOfCharacteristicTypes.cpp
@@ -1,0 +1,208 @@
+#include "advpropChartOfCharacteristicTypes.h"
+
+#include "backend/propertyManager/property/variant/variantOwner.h"
+#include "backend/propertyManager/property/propertyChartOfCharacteristicTypes.h"
+
+#include "frontend/propertyManager/property/private/prop.h"
+#include "frontend/propertyManager/propertyEditor.h"
+
+#define icon_size 16
+
+// -----------------------------------------------------------------------
+// ibPGChartOfCharacteristicTypesProperty
+// -----------------------------------------------------------------------
+
+wxPG_IMPLEMENT_PROPERTY_CLASS(ibPGChartOfCharacteristicTypesProperty, wxPGProperty, ComboBoxAndButton)
+
+// register frontend property
+class ibPropertyChartOfCharacteristicTypesLoader
+{
+public:
+	ibPropertyChartOfCharacteristicTypesLoader()
+	{
+		ibPG_IMPLEMENT_PROPERTY_CALLBACK(ibPGChartOfCharacteristicTypesProperty, ibPropertyChartOfCharacteristicTypes::ms_propertyChartOfCharacteristicTypes);
+	}
+}g_chartOfCharacteristicTypesLoader;
+
+#include "backend/metadata.h"
+
+void ibPGChartOfCharacteristicTypesProperty::FillByClsid(const ibClassID& clsid)
+{
+	const ibValueMetaObjectGenericData* metaGenericData = dynamic_cast<const ibValueMetaObjectGenericData*>(m_ownerProperty);
+	if (metaGenericData != nullptr) {
+		const ibMetaData* metaData = metaGenericData->GetMetaData();
+		wxASSERT(metaData);
+		for (auto metaOwner : metaData->GetAnyArrayObject(clsid)) {
+			m_choices.Add(metaOwner->GetName(), metaOwner->GetIcon(), metaOwner->GetMetaID());
+		}
+	}
+}
+
+ibPGChartOfCharacteristicTypesProperty::ibPGChartOfCharacteristicTypesProperty(const ibPropertyObject* property, const wxString& label, const wxString& strName, const wxVariant& value)
+	: wxPGProperty(label, strName), m_ownerProperty(property)
+{
+	FillByClsid(g_metaChartOfCharacteristicTypesCLSID);
+
+	//m_flags |= wxPGFlags::ReadOnly;
+	m_flags |= wxPGPropertyFlags_ActiveButton; // Property button always enabled.
+
+	SetValue(value);
+}
+
+wxString ibPGChartOfCharacteristicTypesProperty::ValueToString( wxVariant& value, wxPGPropValFormatFlags flags ) const
+{
+	return value.GetString();
+}
+
+bool ibPGChartOfCharacteristicTypesProperty::StringToValue(wxVariant& variant,
+	const wxString& text,
+	wxPGPropValFormatFlags flags) const
+{
+	return false;
+}
+
+bool ibPGChartOfCharacteristicTypesProperty::IntToValue(wxVariant& value, int number, wxPGPropValFormatFlags flags) const
+{
+	ibVariantDataOwner* dataOwner = property_cast(value, ibVariantDataOwner);
+	if (dataOwner != nullptr) {
+		ibVariantDataOwner* newDataOwner = dataOwner->Clone();
+		wxASSERT(newDataOwner);
+		ibMetaDescription& md = newDataOwner->GetMetaDesc();
+		md.SetDefaultMetaType(m_choices.GetValue(number));
+		value = newDataOwner;
+		return true;
+	}
+	return false;
+}
+
+#include "frontend/win/ctrls/checktree.h"
+
+wxPGEditorDialogAdapter* ibPGChartOfCharacteristicTypesProperty::GetEditorDialog() const
+{
+	class ibPGEditorChartOfCharacteristicTypesDialogAdapter : public wxPGEditorDialogAdapter {
+
+		class ibTreeItemPropertyData : public wxTreeItemData {
+			ibValueMetaObject* m_metaObject;
+		public:
+			ibTreeItemPropertyData(ibValueMetaObject* opt) : wxTreeItemData(), m_metaObject(opt) {}
+			ibMetaID GetMetaID() const { return m_metaObject->GetMetaID(); }
+		};
+
+		void FillByClsid(ibMetaData* metaData, const ibClassID& clsid,
+			ibCheckTree* tc, ibVariantDataOwner* data) {
+
+			wxImageList* imageList = tc->GetImageList();
+			wxASSERT(imageList);
+			const ibCtorAbstractType* so = ibValue::GetAvailableCtor(clsid);
+			int groupIcon = imageList->Add(so->GetClassIcon());
+			const wxTreeItemId& parentID = tc->AppendItem(tc->GetRootItem(), so->GetClassName(),
+				groupIcon, groupIcon);
+			for (auto metaObject : metaData->GetAnyArrayObject(clsid)) {
+				ibValueMetaObjectRecordDataRef* registerData = dynamic_cast<ibValueMetaObjectRecordDataRef*>(metaObject);
+				if (registerData != nullptr) {
+					{
+						int icon = imageList->Add(registerData->GetIcon());
+						ibTreeItemPropertyData* itemData = new ibTreeItemPropertyData(metaObject);
+						wxTreeItemId newItem = tc->AppendItem(parentID, registerData->GetName(),
+							icon, icon,
+							itemData);
+
+						if (data != nullptr) {
+							const ibMetaDescription& md = data->GetMetaDesc();
+							tc->SetItemState(newItem, md.ContainMetaType(registerData->GetMetaID()) ? ibCheckTree::CHECKED : ibCheckTree::UNCHECKED);
+							tc->Check(newItem, md.ContainMetaType(registerData->GetMetaID()));
+						}
+						else {
+							tc->SetItemState(newItem, ibCheckTree::UNCHECKED);
+							tc->Check(newItem, false);
+						}
+					}
+				}
+			}
+		}
+
+	public:
+
+		virtual bool DoShowDialog(wxPropertyGrid* pg, wxPGProperty* prop) wxOVERRIDE
+		{
+			ibPGChartOfCharacteristicTypesProperty* dlgProp = wxDynamicCast(prop, ibPGChartOfCharacteristicTypesProperty);
+			wxCHECK_MSG(dlgProp, false, "Function called for incompatible property");
+
+			ibVariantDataOwner* data = property_cast(dlgProp->GetValue(), ibVariantDataOwner);
+			if (data == nullptr) return false;
+			const ibValueMetaObjectGenericData* metaGenericData = dynamic_cast<const ibValueMetaObjectGenericData*>(dlgProp->GetPropertyObject());
+			if (metaGenericData == nullptr) return false;
+
+			// launch editor dialog
+			wxDialog* dlg = new wxDialog(pg, wxID_ANY, _("Choice chart of characteristic types"), wxDefaultPosition, wxDefaultSize,
+				wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxCLIP_CHILDREN);
+
+			dlg->SetFont(pg->GetFont()); // To allow entering chars of the same set as the propGrid
+
+			// Multi-line text editor dialog.
+			const int spacing = wxPropertyGrid::IsSmallScreen() ? 4 : 8;
+			wxBoxSizer* topsizer = new wxBoxSizer(wxVERTICAL);
+			wxBoxSizer* rowsizer = new wxBoxSizer(wxHORIZONTAL);
+
+			ibCheckTree* tc = new ibCheckTree(dlg, wxID_ANY,
+				wxDefaultPosition, wxDefaultSize, wxTR_HAS_BUTTONS | wxTR_LINES_AT_ROOT | wxTR_NO_LINES | wxTR_HIDE_ROOT | wxCR_MULTIPLE_CHECK | wxCR_EMPTY_CHECK | wxSUNKEN_BORDER | wxTR_TWIST_BUTTONS);
+
+			wxTreeItemId rootItem = tc->AddRoot(wxEmptyString);
+
+			rowsizer->Add(tc, wxSizerFlags(1).Expand().Border(wxALL, spacing));
+			topsizer->Add(rowsizer, wxSizerFlags(1).Expand());
+
+			tc->SetDoubleBuffered(true);
+			tc->Enable(!dlgProp->HasFlag(wxPGFlags::ReadOnly));
+
+			wxStdDialogButtonSizer* buttonSizer = dlg->CreateStdDialogButtonSizer(wxOK | wxCANCEL);
+			topsizer->Add(buttonSizer, wxSizerFlags(0).Right().Border(wxBOTTOM | wxRIGHT, spacing));
+
+			dlg->SetSizer(topsizer);
+			topsizer->SetSizeHints(dlg);
+
+			if (!wxPropertyGrid::IsSmallScreen()) {
+				dlg->SetSize(400, 300);
+				dlg->Move(pg->GetGoodEditorDialogPosition(prop, dlg->GetSize()));
+			}
+
+			tc->SetFocus();
+
+			// Make an state image list containing small icons
+			tc->AssignImageList(
+				new wxImageList(icon_size, icon_size)
+			);
+
+			ibMetaData* metaData = metaGenericData->GetMetaData();
+			wxASSERT(metaData);
+			if (metaData != nullptr) {
+				FillByClsid(metaData, g_metaChartOfCharacteristicTypesCLSID, tc, data);
+			}
+
+			tc->ExpandAll(); int res = dlg->ShowModal();
+
+			ibVariantDataOwner* clone = data->Clone();
+			{
+				ibMetaDescription& metaDesc = clone->GetMetaDesc(); metaDesc.ClearMetaType();
+				wxArrayTreeItemIds ids;
+				unsigned int selCount = tc->GetSelections(ids);
+				for (const wxTreeItemId& selItem : ids) {
+					if (selItem.IsOk()) {
+						wxTreeItemData* dataItem = tc->GetItemData(selItem);
+						if (dataItem && res == wxID_OK) {
+							ibTreeItemPropertyData* item = dynamic_cast<ibTreeItemPropertyData*>(dataItem);
+							wxASSERT(item);
+							metaDesc.AppendMetaType(item->GetMetaID());
+						}
+					}
+				}
+			}
+			SetValue(clone);
+
+			dlg->Destroy();
+			return res == wxID_OK;
+		}
+	};
+
+	return new ibPGEditorChartOfCharacteristicTypesDialogAdapter();
+}

--- a/src/engine/frontend/propertyManager/property/advprop/advpropChartOfCharacteristicTypes.h
+++ b/src/engine/frontend/propertyManager/property/advprop/advpropChartOfCharacteristicTypes.h
@@ -1,0 +1,41 @@
+#ifndef __ADVPROP_CHART_OF_CHARACTERISTIC_TYPES_H__
+#define __ADVPROP_CHART_OF_CHARACTERISTIC_TYPES_H__
+
+#include <wx/propgrid/propgrid.h>
+#include "backend/backend_type.h"
+
+class BACKEND_API ibPropertyObject;
+
+// -----------------------------------------------------------------------
+// ibPGChartOfCharacteristicTypesProperty
+// -----------------------------------------------------------------------
+
+class ibPGChartOfCharacteristicTypesProperty : public wxPGProperty {
+	void FillByClsid(const ibClassID& clsid);
+public:
+
+	const ibPropertyObject* GetPropertyObject() const { return m_ownerProperty; }
+
+	ibPGChartOfCharacteristicTypesProperty(const ibPropertyObject* property = nullptr, const wxString& label = wxPG_LABEL,
+		const wxString& name = wxPG_LABEL, const wxVariant& value = wxNullVariant);
+
+	virtual wxString ValueToString(wxVariant& value,
+		wxPGPropValFormatFlags flags = wxPGPropValFormatFlags::Null) const override;
+
+	virtual bool StringToValue(wxVariant& variant,
+		const wxString& text,
+		wxPGPropValFormatFlags flags = wxPGPropValFormatFlags::Null) const override;
+
+	virtual bool IntToValue(wxVariant& value,
+		int number,
+		wxPGPropValFormatFlags flags = wxPGPropValFormatFlags::Null) const override;
+
+	virtual wxPGEditorDialogAdapter* GetEditorDialog() const override;
+
+protected:
+	const ibPropertyObject* m_ownerProperty = nullptr;
+private:
+	WX_PG_DECLARE_PROPERTY_CLASS(ibPGChartOfCharacteristicTypesProperty);
+};
+
+#endif


### PR DESCRIPTION
## Summary

Fixes owner dialog showing ПВХ and ChartOfAccounts alongside Catalogs.

### Problem
ibPropertyOwner was used for all three bindings (Catalog Owner, ChartOfAccounts→ПВХ, AccountingRegister→ChartOfAccounts), causing mixed object types in choice dialog.

### Solution
Created dedicated property classes with their own CLSID filters:

| Property Class | Shows | Used In |
|---|---|---|
| ibPropertyOwner | Only Catalogs | Catalog → Owner |
| ibPropertyChartOfCharacteristicTypes | Only ПВХ | ChartOfAccounts → ПВХ |
| ibPropertyChartOfAccounts | Only Charts of Accounts | AccountingRegister → Chart of Accounts |

### New files (backend)
- propertyChartOfCharacteristicTypes.h/.cpp
- propertyChartOfAccounts.h/.cpp

### New files (frontend)
- advpropChartOfCharacteristicTypes.h/.cpp — UI for ПВХ selection
- advpropChartOfAccounts.h/.cpp — UI for Chart of Accounts selection

### Modified
- chartOfAccounts.h — ibPropertyOwner → ibPropertyChartOfCharacteristicTypes
- accountingRegister.h — ibPropertyOwner → ibPropertyChartOfAccounts

## Test plan
- [ ] Chart of Accounts → "Chart of characteristic types" property shows only ПВХ
- [ ] Accounting Register → "Chart of accounts" property shows only Charts of Accounts
- [ ] Catalog → "List owner" property shows only Catalogs (unchanged)