### PR TITLE
Fix C2440: property type mismatch in XML/JSON serialization

### DIFF
--- a/src/engine/backend/metadataConfigurationJSON.cpp
+++ b/src/engine/backend/metadataConfigurationJSON.cpp
@@ -673,7 +673,7 @@ void SaveChartOfAccountsToJSON(json& jObj, ibValueMetaObjectChartOfAccounts* cha
 	jObj["defaultForms"] = jDefForms;
 
 	// ChartOfCharacteristicTypes owner property
-	ibPropertyOwner* chrtProp = chart->GetChartOfCharacteristicTypes();
+	ibPropertyChartOfCharacteristicTypes* chrtProp = chart->GetChartOfCharacteristicTypes();
 	if (chrtProp != nullptr) {
 		jObj["chartOfCharacteristicTypes"] = SaveMetaDescriptionToJSON(chrtProp->GetValueAsMetaDesc());
 	}

--- a/src/engine/backend/metadataConfigurationXML.cpp
+++ b/src/engine/backend/metadataConfigurationXML.cpp
@@ -694,7 +694,7 @@ void SaveChartOfAccountsToXML(wxXmlNode* xmlObj, ibValueMetaObjectChartOfAccount
 	xmlObj->AddChild(xmlDefForms);
 
 	// ChartOfCharacteristicTypes owner property
-	ibPropertyOwner* chrtProp = chart->GetChartOfCharacteristicTypes();
+	ibPropertyChartOfCharacteristicTypes* chrtProp = chart->GetChartOfCharacteristicTypes();
 	if (chrtProp != nullptr) {
 		SaveMetaDescriptionToXML(xmlObj, wxT("ChartOfCharacteristicTypes"), chrtProp->GetValueAsMetaDesc());
 	}


### PR DESCRIPTION
Fixes compile error: cannot convert ibPropertyChartOfCharacteristicTypes* to ibPropertyOwner*