### PR TITLE
Fix LNK2001: add property .cpp/.h files to vcxproj

### DIFF
--- a/src/engine/backend/backend.vcxproj
+++ b/src/engine/backend/backend.vcxproj
@@ -209,6 +209,8 @@
     <ClInclude Include="propertyManager\property\propertyNumber.h" />
     <ClInclude Include="propertyManager\property\propertyList.h" />
     <ClInclude Include="propertyManager\property\propertyOwner.h" />
+    <ClInclude Include="propertyManager\property\propertyChartOfCharacteristicTypes.h" />
+    <ClInclude Include="propertyManager\property\propertyChartOfAccounts.h" />
     <ClInclude Include="propertyManager\property\propertyPicture.h" />
     <ClInclude Include="propertyManager\property\propertyPoint.h" />
     <ClInclude Include="propertyManager\property\propertyRecord.h" />
@@ -521,6 +523,8 @@
     <ClCompile Include="propertyManager\property\propertyNumber.cpp" />
     <ClCompile Include="propertyManager\property\propertyList.cpp" />
     <ClCompile Include="propertyManager\property\propertyOwner.cpp" />
+    <ClCompile Include="propertyManager\property\propertyChartOfCharacteristicTypes.cpp" />
+    <ClCompile Include="propertyManager\property\propertyChartOfAccounts.cpp" />
     <ClCompile Include="propertyManager\property\propertyPicture.cpp" />
     <ClCompile Include="propertyManager\property\propertyPictureExt.cpp" />
     <ClCompile Include="propertyManager\property\propertyPoint.cpp" />


### PR DESCRIPTION
Fixes unresolved external symbol ms_propertyChartOfCharacteristicTypes and ms_propertyChartOfAccounts.