### PR TITLE
Fix LNK2001: add advprop files to frontend.vcxproj

### DIFF
--- a/src/engine/frontend/frontend.vcxproj
+++ b/src/engine/frontend/frontend.vcxproj
@@ -58,6 +58,8 @@
     <ClCompile Include="propertyManager\property\advprop\advpropModule.cpp" />
     <ClCompile Include="propertyManager\property\advprop\advpropNumber.cpp" />
     <ClCompile Include="propertyManager\property\advprop\advpropOwner.cpp" />
+    <ClCompile Include="propertyManager\property\advprop\advpropChartOfCharacteristicTypes.cpp" />
+    <ClCompile Include="propertyManager\property\advprop\advpropChartOfAccounts.cpp" />
     <ClCompile Include="propertyManager\property\advprop\advpropPicture.cpp" />
     <ClCompile Include="propertyManager\property\advprop\advpropPoint.cpp" />
     <ClCompile Include="propertyManager\property\advprop\advpropRecord.cpp" />
@@ -357,6 +359,8 @@
     <ClInclude Include="propertyManager\property\advprop\advpropModule.h" />
     <ClInclude Include="propertyManager\property\advprop\advpropNumber.h" />
     <ClInclude Include="propertyManager\property\advprop\advpropOwner.h" />
+    <ClInclude Include="propertyManager\property\advprop\advpropChartOfCharacteristicTypes.h" />
+    <ClInclude Include="propertyManager\property\advprop\advpropChartOfAccounts.h" />
     <ClInclude Include="propertyManager\property\advprop\advpropPicture.h" />
     <ClInclude Include="propertyManager\property\advprop\advpropPoint.h" />
     <ClInclude Include="propertyManager\property\advprop\advpropRecord.h" />


### PR DESCRIPTION
Adds advpropChartOfCharacteristicTypes.cpp/.h and advpropChartOfAccounts.cpp/.h to frontend.vcxproj. Fixes linker errors for ms_propertyChartOfCharacteristicTypes and ms_propertyChartOfAccounts.