### PR TITLE
Fix: CLSID as u64 number in XML/JSON (no trailing spaces)

### DIFF
--- a/src/engine/backend/metadataConfigurationJSON.cpp
+++ b/src/engine/backend/metadataConfigurationJSON.cpp
@@ -64,7 +64,7 @@ json SaveTypeDescriptionToJSON(const ibTypeDescription& typeDesc)
 
 	json jTypeIds = json::array();
 	for (const auto& clsid : clsidList) {
-		jTypeIds.push_back(WxToStd(clsid_to_string(clsid)));
+		jTypeIds.push_back((unsigned long long)clsid);
 	}
 	jType["typeIds"] = jTypeIds;
 
@@ -737,7 +737,7 @@ json SaveMetaObjectToJSON(ibValueMetaObject* metaObject)
 	json jObj = json::object();
 	jObj["guid"] = WxToStd(metaObject->GetGuid().str());
 	jObj["id"] = metaObject->GetMetaID();
-	jObj["clsid"] = WxToStd(clsid_to_string(metaObject->GetClassType()));
+	jObj["clsid"] = (unsigned long long)metaObject->GetClassType();
 	jObj["name"] = WxToStd(metaObject->GetName());
 
 	const wxString synonym = metaObject->GetSynonym();

--- a/src/engine/backend/metadataConfigurationXML.cpp
+++ b/src/engine/backend/metadataConfigurationXML.cpp
@@ -63,7 +63,7 @@ void SaveTypeDescriptionToXML(wxXmlNode* parent, const ibTypeDescription& typeDe
 
 	wxXmlNode* xmlType = new wxXmlNode(wxXML_ELEMENT_NODE, wxT("Type"));
 	for (const auto& clsid : clsidList) {
-		AddTextNode(xmlType, wxT("TypeId"), clsid_to_string(clsid));
+		AddTextNode(xmlType, wxT("TypeId"), wxString::Format(wxT("%llu"), (unsigned long long)clsid));
 	}
 
 	// Number qualifiers
@@ -764,7 +764,7 @@ void SaveMetaObjectToXML(wxXmlNode* parent, ibValueMetaObject* metaObject, const
 	wxXmlNode* xmlObj = new wxXmlNode(wxXML_ELEMENT_NODE, elementName);
 	xmlObj->AddAttribute(wxT("guid"), metaObject->GetGuid().str());
 	xmlObj->AddAttribute(wxT("id"), wxString::Format(wxT("%d"), metaObject->GetMetaID()));
-	xmlObj->AddAttribute(wxT("clsid"), clsid_to_string(metaObject->GetClassType()));
+	xmlObj->AddAttribute(wxT("clsid"), wxString::Format(wxT("%llu"), (unsigned long long)metaObject->GetClassType()));
 
 	AddTextNode(xmlObj, wxT("Name"), metaObject->GetName());
 


### PR DESCRIPTION
Replaces clsid_to_string() with numeric u64 in TypeId and clsid attributes. Fixes trailing spaces issue.