### PR TITLE
Wrap SubcontoKindsTable in ibPropertyInnerAttribute

### DIFF
--- a/src/engine/backend/metaCollection/partial/chartOfAccounts.h
+++ b/src/engine/backend/metaCollection/partial/chartOfAccounts.h
@@ -249,9 +249,8 @@ private:
 	/////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// Predefined tabular section "SubcontoKinds" — own meta class with predefined columns
 	// Created manually because ibPropertyInnerAttribute template can't pass args to non-default constructor via wxClassInfo
-	ibValueMetaObjectSubcontoKindsTable* m_subcontoKindsTable = nullptr;
-
-	void InitSubcontoKindsTable();
+	ibPropertyInnerAttribute<ibValueMetaObjectSubcontoKindsTable>* m_propertySubcontoKindsTable =
+		ibPropertyObject::CreateProperty<ibPropertyInnerAttribute<ibValueMetaObjectSubcontoKindsTable>>(m_categoryAccounting, wxT("SubcontoKinds"), _("Subconto kinds"));
 
 	friend class ibValueRecordDataObjectChartOfAccounts;
 	friend class ibMetaData;

--- a/src/engine/backend/metaCollection/partial/chartOfAccountsMetadata.cpp
+++ b/src/engine/backend/metaCollection/partial/chartOfAccountsMetadata.cpp
@@ -140,28 +140,16 @@ bool ibValueMetaObjectChartOfAccounts::SaveData(ibWriterMemory& dataWritter)
 	return ibValueMetaObjectRecordDataHierarchyMutableRef::SaveData(dataWritter);
 }
 
-void ibValueMetaObjectChartOfAccounts::InitSubcontoKindsTable()
-{
-	if (m_subcontoKindsTable == nullptr) {
-		m_subcontoKindsTable = CreateMetaObjectAndSetParent<ibValueMetaObjectSubcontoKindsTable>();
-		m_subcontoKindsTable->SetName(wxT("SubcontoKinds"));
-		m_subcontoKindsTable->SetSynonym(_("Subconto kinds"));
-	}
-}
-
 bool ibValueMetaObjectChartOfAccounts::OnCreateMetaObject(ibMetaData* metaData, int flags)
 {
 	if (!ibValueMetaObjectRecordDataHierarchyMutableRef::OnCreateMetaObject(metaData, flags)) return false;
-
-	// Create predefined SubcontoKinds table
-	InitSubcontoKindsTable();
 
 	return (*m_propertyAttributeAccountType)->OnCreateMetaObject(metaData, flags) &&
 		(*m_propertyAttributeOffBalance)->OnCreateMetaObject(metaData, flags) &&
 		(*m_propertyAttributeQuantitative)->OnCreateMetaObject(metaData, flags) &&
 		(*m_propertyAttributeCurrency)->OnCreateMetaObject(metaData, flags) &&
 		(*m_propertyAttributeMaxSubcontoCount)->OnCreateMetaObject(metaData, flags) &&
-		m_subcontoKindsTable->OnCreateMetaObject(metaData, flags) &&
+		(*m_propertySubcontoKindsTable)->OnCreateMetaObject(metaData, flags) &&
 		(*m_propertyModuleObject)->OnCreateMetaObject(metaData, flags) &&
 		(*m_propertyModuleManager)->OnCreateMetaObject(metaData, flags);
 }
@@ -173,15 +161,7 @@ bool ibValueMetaObjectChartOfAccounts::OnLoadMetaObject(ibMetaData* metaData)
 	if (!(*m_propertyAttributeQuantitative)->OnLoadMetaObject(metaData)) return false;
 	if (!(*m_propertyAttributeCurrency)->OnLoadMetaObject(metaData)) return false;
 	if (!(*m_propertyAttributeMaxSubcontoCount)->OnLoadMetaObject(metaData)) return false;
-
-	// Find SubcontoKinds table from loaded children
-	for (auto table : GetTableArrayObject()) {
-		if (table->GetName() == wxT("SubcontoKinds")) {
-			m_subcontoKindsTable = dynamic_cast<ibValueMetaObjectSubcontoKindsTable*>(table);
-			break;
-		}
-	}
-	if (m_subcontoKindsTable != nullptr && !m_subcontoKindsTable->OnLoadMetaObject(metaData)) return false;
+	if (!(*m_propertySubcontoKindsTable)->OnLoadMetaObject(metaData)) return false;
 	if (!(*m_propertyModuleObject)->OnLoadMetaObject(metaData)) return false;
 	if (!(*m_propertyModuleManager)->OnLoadMetaObject(metaData)) return false;
 	return ibValueMetaObjectRecordDataHierarchyMutableRef::OnLoadMetaObject(metaData);
@@ -194,7 +174,7 @@ bool ibValueMetaObjectChartOfAccounts::OnSaveMetaObject(int flags)
 	if (!(*m_propertyAttributeQuantitative)->OnSaveMetaObject(flags)) return false;
 	if (!(*m_propertyAttributeCurrency)->OnSaveMetaObject(flags)) return false;
 	if (!(*m_propertyAttributeMaxSubcontoCount)->OnSaveMetaObject(flags)) return false;
-	if (m_subcontoKindsTable != nullptr && !m_subcontoKindsTable->OnSaveMetaObject(flags)) return false;
+	if (!(*m_propertySubcontoKindsTable)->OnSaveMetaObject(flags)) return false;
 	if (!(*m_propertyModuleObject)->OnSaveMetaObject(flags)) return false;
 	if (!(*m_propertyModuleManager)->OnSaveMetaObject(flags)) return false;
 	return ibValueMetaObjectRecordDataHierarchyMutableRef::OnSaveMetaObject(flags);
@@ -207,7 +187,7 @@ bool ibValueMetaObjectChartOfAccounts::OnDeleteMetaObject()
 	if (!(*m_propertyAttributeQuantitative)->OnDeleteMetaObject()) return false;
 	if (!(*m_propertyAttributeCurrency)->OnDeleteMetaObject()) return false;
 	if (!(*m_propertyAttributeMaxSubcontoCount)->OnDeleteMetaObject()) return false;
-	if (m_subcontoKindsTable != nullptr && !m_subcontoKindsTable->OnDeleteMetaObject()) return false;
+	if (!(*m_propertySubcontoKindsTable)->OnDeleteMetaObject()) return false;
 	if (!(*m_propertyModuleObject)->OnDeleteMetaObject()) return false;
 	if (!(*m_propertyModuleManager)->OnDeleteMetaObject()) return false;
 	return ibValueMetaObjectRecordDataHierarchyMutableRef::OnDeleteMetaObject();
@@ -234,7 +214,7 @@ bool ibValueMetaObjectChartOfAccounts::OnBeforeRunMetaObject(int flags)
 	if (!(*m_propertyAttributeQuantitative)->OnBeforeRunMetaObject(flags)) return false;
 	if (!(*m_propertyAttributeCurrency)->OnBeforeRunMetaObject(flags)) return false;
 	if (!(*m_propertyAttributeMaxSubcontoCount)->OnBeforeRunMetaObject(flags)) return false;
-	if (m_subcontoKindsTable != nullptr && !m_subcontoKindsTable->OnBeforeRunMetaObject(flags)) return false;
+	if (!(*m_propertySubcontoKindsTable)->OnBeforeRunMetaObject(flags)) return false;
 	if (!(*m_propertyModuleObject)->OnBeforeRunMetaObject(flags)) return false;
 	if (!(*m_propertyModuleManager)->OnBeforeRunMetaObject(flags)) return false;
 	registerSelection();
@@ -252,7 +232,7 @@ bool ibValueMetaObjectChartOfAccounts::OnAfterRunMetaObject(int flags)
 	if (!(*m_propertyAttributeQuantitative)->OnAfterRunMetaObject(flags)) return false;
 	if (!(*m_propertyAttributeCurrency)->OnAfterRunMetaObject(flags)) return false;
 	if (!(*m_propertyAttributeMaxSubcontoCount)->OnAfterRunMetaObject(flags)) return false;
-	if (m_subcontoKindsTable != nullptr && !m_subcontoKindsTable->OnAfterRunMetaObject(flags)) return false;
+	if (!(*m_propertySubcontoKindsTable)->OnAfterRunMetaObject(flags)) return false;
 	if (!(*m_propertyModuleObject)->OnAfterRunMetaObject(flags)) return false;
 	if (!(*m_propertyModuleManager)->OnAfterRunMetaObject(flags)) return false;
 
@@ -261,7 +241,7 @@ bool ibValueMetaObjectChartOfAccounts::OnAfterRunMetaObject(int flags)
 
 	// Set SubcontoKind column type from ПВХ binding
 	const ibMetaDescription& metaDesc = m_propertyChartOfCharacteristicTypes->GetValueAsMetaDesc();
-	if (m_subcontoKindsTable != nullptr && metaDesc.GetTypeCount() > 0) {
+	if ((*m_propertySubcontoKindsTable) != nullptr && metaDesc.GetTypeCount() > 0) {
 		ibTypeDescription typeDesc;
 		for (unsigned int idx = 0; idx < metaDesc.GetTypeCount(); idx++) {
 			const ibValueMetaObject* chartOfCharTypes = m_metaData->FindAnyObjectByFilter(metaDesc.GetByIdx(idx));
@@ -272,12 +252,12 @@ bool ibValueMetaObjectChartOfAccounts::OnAfterRunMetaObject(int flags)
 			}
 		}
 		// Update SubcontoKind column type in predefined table
-		ibValueMetaObjectAttributeBase* kindAttr = m_subcontoKindsTable->GetSubcontoKind();
+		ibValueMetaObjectAttributeBase* kindAttr = (*m_propertySubcontoKindsTable)->GetSubcontoKind();
 		if (kindAttr != nullptr) {
 			kindAttr->GetTypeDesc().SetDefaultMetaType(typeDesc);
 		}
 		// Prevent deletion of predefined tabular section
-		m_subcontoKindsTable->SetFlag(metaDisableFlag);
+		(*m_propertySubcontoKindsTable)->SetFlag(metaDisableFlag);
 	}
 
 	if (appData->DesignerMode()) {
@@ -295,7 +275,7 @@ bool ibValueMetaObjectChartOfAccounts::OnBeforeCloseMetaObject()
 	if (!(*m_propertyAttributeQuantitative)->OnBeforeCloseMetaObject()) return false;
 	if (!(*m_propertyAttributeCurrency)->OnBeforeCloseMetaObject()) return false;
 	if (!(*m_propertyAttributeMaxSubcontoCount)->OnBeforeCloseMetaObject()) return false;
-	if (m_subcontoKindsTable != nullptr && !m_subcontoKindsTable->OnBeforeCloseMetaObject()) return false;
+	if (!(*m_propertySubcontoKindsTable)->OnBeforeCloseMetaObject()) return false;
 	if (!(*m_propertyModuleObject)->OnBeforeCloseMetaObject()) return false;
 	if (!(*m_propertyModuleManager)->OnBeforeCloseMetaObject()) return false;
 	ibValueModuleManager* moduleManager = m_metaData->GetModuleManager();
@@ -315,7 +295,7 @@ bool ibValueMetaObjectChartOfAccounts::OnAfterCloseMetaObject()
 	if (!(*m_propertyAttributeQuantitative)->OnAfterCloseMetaObject()) return false;
 	if (!(*m_propertyAttributeCurrency)->OnAfterCloseMetaObject()) return false;
 	if (!(*m_propertyAttributeMaxSubcontoCount)->OnAfterCloseMetaObject()) return false;
-	if (m_subcontoKindsTable != nullptr && !m_subcontoKindsTable->OnAfterCloseMetaObject()) return false;
+	if (!(*m_propertySubcontoKindsTable)->OnAfterCloseMetaObject()) return false;
 	if (!(*m_propertyModuleObject)->OnAfterCloseMetaObject()) return false;
 	if (!(*m_propertyModuleManager)->OnAfterCloseMetaObject()) return false;
 	unregisterSelection();


### PR DESCRIPTION
Wraps m_subcontoKindsTable in ibPropertyInnerAttribute for copy/compare support. Removes InitSubcontoKindsTable().