### PR TITLE
Complete accounting register: DrCrTurnovers, WriteRecordSet, full object

### DIFF
--- a/src/engine/backend/metaCollection/partial/accountingRegisterManager_impl.cpp
+++ b/src/engine/backend/metaCollection/partial/accountingRegisterManager_impl.cpp
@@ -657,8 +657,6 @@ ibValue ibValueManagerDataObjectAccountingRegister::DrCrTurnovers(const ibValue&
 	else if (db_query == nullptr)
 		ibBackendCoreException::Error(_("Database is not open!"));
 
-	// DrCrTurnovers requires a complex correlated subquery (debit account x credit account pairs).
-	// Return empty table with proper column structure for now.
 	ibValueModelTable* retTable = ibValue::CreateAndPrepareValueRef<ibValueModelTable>();
 	ibValueModelTable::ibValueModelColumnCollection* colCollection = retTable->GetColumnCollection();
 	wxASSERT(colCollection);
@@ -691,6 +689,268 @@ ibValue ibValueManagerDataObjectAccountingRegister::DrCrTurnovers(const ibValue&
 			object->GetSynonym() + " " + _("Amount")
 		);
 	}
+
+	// Parse dimension filter
+	ibValueStructure* valFilter = nullptr; std::map<ibValueMetaObjectAttributeBase*, ibValue> selFilter;
+	if (cFilter.ConvertToValue(valFilter)) {
+		for (const auto object : m_metaObject->GetDimentionArrayObject()) {
+			ibValue vSelValue;
+			if (valFilter->Property(object->GetName(), vSelValue)) {
+				selFilter.insert_or_assign(
+					object, vSelValue
+				);
+			}
+		}
+	}
+
+	// Check if account filter is provided
+	bool hasAccountFilter = !cAccount.IsEmpty();
+
+	// Get SQL field info for key columns
+	wxString accountFieldName = m_metaObject->GetRegisterAccount()->GetFieldNameDB();
+	ibValueMetaObjectAttributeBase::ibSQLField sqlColAccount =
+		ibValueMetaObjectAttributeBase::GetSQLFieldData(m_metaObject->GetRegisterAccount());
+	ibValueMetaObjectAttributeBase::ibSQLField sqlColRecordType =
+		ibValueMetaObjectAttributeBase::GetSQLFieldData(m_metaObject->GetRegisterRecordType());
+	ibValueMetaObjectAttributeBase::ibSQLField sqlColRecorder =
+		ibValueMetaObjectAttributeBase::GetSQLFieldData(m_metaObject->GetRegisterRecorder());
+	ibValueMetaObjectAttributeBase::ibSQLField sqlColLineNumber =
+		ibValueMetaObjectAttributeBase::GetSQLFieldData(m_metaObject->GetRegisterLineNumber());
+
+	// DrCrTurnovers: self-join on Recorder+LineNumber to pair debit and credit rows.
+	// dr alias = debit side (RecordType=0), cr alias = credit side (RecordType=1).
+	//
+	// The outer SELECT wraps the inner self-join to produce column names
+	// compatible with GetValueAttribute (fieldName_TYPE, fieldName_N, fieldName_RTRef, etc.).
+	// AccountDr uses prefix "AccountDr" and AccountCr uses prefix "AccountCr".
+
+	wxString tableName = m_metaObject->GetTableNameDB();
+
+	// --- Outer SELECT: aliases for GetValueAttribute compatibility ---
+	wxString sqlQuery = " SELECT ";
+
+	// AccountDr fields: alias dr.Account sub-columns to AccountDr_TYPE, AccountDr_B, AccountDr_RTRef, AccountDr_RRRef etc.
+	{
+		sqlQuery += "dr." + sqlColAccount.m_fieldTypeName + " AS AccountDr_TYPE";
+		for (auto dataType : sqlColAccount.m_types) {
+			if (dataType.m_type != ibValueMetaObjectAttributeBase::ibFieldTypes::ibFieldTypes_Reference) {
+				// e.g. fieldName_N -> AccountDr_N, fieldName_B -> AccountDr_B, etc.
+				wxString suffix = dataType.m_field.m_fieldName.Mid(accountFieldName.Len());
+				sqlQuery += ", dr." + dataType.m_field.m_fieldName + " AS AccountDr" + suffix;
+			}
+			else {
+				sqlQuery += ", dr." + dataType.m_field.m_fieldRefName.m_fieldRefType + " AS AccountDr_RTRef";
+				sqlQuery += ", dr." + dataType.m_field.m_fieldRefName.m_fieldRefName + " AS AccountDr_RRRef";
+			}
+		}
+	}
+
+	// AccountCr fields: alias cr.Account sub-columns to AccountCr_TYPE, AccountCr_N, AccountCr_RTRef, etc.
+	{
+		sqlQuery += ", cr." + sqlColAccount.m_fieldTypeName + " AS AccountCr_TYPE";
+		for (auto dataType : sqlColAccount.m_types) {
+			if (dataType.m_type != ibValueMetaObjectAttributeBase::ibFieldTypes::ibFieldTypes_Reference) {
+				wxString suffix = dataType.m_field.m_fieldName.Mid(accountFieldName.Len());
+				sqlQuery += ", cr." + dataType.m_field.m_fieldName + " AS AccountCr" + suffix;
+			}
+			else {
+				sqlQuery += ", cr." + dataType.m_field.m_fieldRefName.m_fieldRefType + " AS AccountCr_RTRef";
+				sqlQuery += ", cr." + dataType.m_field.m_fieldRefName.m_fieldRefName + " AS AccountCr_RRRef";
+			}
+		}
+	}
+
+	// Resource amount aggregates: SUM(dr.Amount)
+	for (const auto object : m_metaObject->GetResourceArrayObject()) {
+		ibValueMetaObjectAttributeBase::ibSQLField sqlResource = ibValueMetaObjectAttributeBase::GetSQLFieldData(object);
+		sqlQuery += ", dr." + sqlResource.m_fieldTypeName;
+		sqlQuery += ", CAST(SUM(dr." + sqlResource.m_types[0].m_field.m_fieldName + ") AS NUMERIC) AS " + sqlResource.m_types[0].m_field.m_fieldName + "_Amount_";
+	}
+
+	// FROM with self-join
+	sqlQuery += " FROM " + tableName + " dr";
+	sqlQuery += " INNER JOIN " + tableName + " cr ON ";
+
+	// Join on Recorder
+	{
+		bool firstJoin = true;
+		for (auto dataType : sqlColRecorder.m_types) {
+			if (!firstJoin) sqlQuery += " AND ";
+			if (dataType.m_type != ibValueMetaObjectAttributeBase::ibFieldTypes::ibFieldTypes_Reference) {
+				sqlQuery += "dr." + dataType.m_field.m_fieldName + " = cr." + dataType.m_field.m_fieldName;
+			}
+			else {
+				sqlQuery += "dr." + dataType.m_field.m_fieldRefName.m_fieldRefType + " = cr." + dataType.m_field.m_fieldRefName.m_fieldRefType;
+				sqlQuery += " AND dr." + dataType.m_field.m_fieldRefName.m_fieldRefName + " = cr." + dataType.m_field.m_fieldRefName.m_fieldRefName;
+			}
+			firstJoin = false;
+		}
+	}
+
+	// Join on LineNumber
+	{
+		sqlQuery += " AND dr." + sqlColLineNumber.m_types[0].m_field.m_fieldName + " = cr." + sqlColLineNumber.m_types[0].m_field.m_fieldName;
+	}
+
+	// WHERE clause
+	sqlQuery += " WHERE ";
+
+	// dr.RecordType = 0 (Debit)
+	sqlQuery += "dr." + sqlColRecordType.m_types[0].m_field.m_fieldName + " = 0.0";
+
+	// cr.RecordType = 1 (Credit)
+	sqlQuery += " AND cr." + sqlColRecordType.m_types[0].m_field.m_fieldName + " = 1.0";
+
+	// dr.Active = true AND cr.Active = true
+	ibValueMetaObjectAttributeBase::ibSQLField sqlColActive =
+		ibValueMetaObjectAttributeBase::GetSQLFieldData(m_metaObject->GetRegisterActive());
+	sqlQuery += " AND dr." + sqlColActive.m_types[0].m_field.m_fieldName + " = ?";
+	sqlQuery += " AND cr." + sqlColActive.m_types[0].m_field.m_fieldName + " = ?";
+
+	// Period range: dr.Period >= ? AND dr.Period <= ?
+	ibValueMetaObjectAttributeBase::ibSQLField sqlColPeriod =
+		ibValueMetaObjectAttributeBase::GetSQLFieldData(m_metaObject->GetRegisterPeriod());
+	sqlQuery += " AND dr." + sqlColPeriod.m_types[0].m_field.m_fieldName + " >= ?";
+	sqlQuery += " AND dr." + sqlColPeriod.m_types[0].m_field.m_fieldName + " <= ?";
+
+	// Account filter on debit side (manually prefixed with dr. for self-join)
+	if (hasAccountFilter) {
+		sqlQuery += " AND dr." + sqlColAccount.m_fieldTypeName + " = ?";
+		for (auto dataType : sqlColAccount.m_types) {
+			if (dataType.m_type != ibValueMetaObjectAttributeBase::ibFieldTypes::ibFieldTypes_Reference) {
+				sqlQuery += " AND dr." + dataType.m_field.m_fieldName + " = ?";
+			}
+			else {
+				sqlQuery += " AND dr." + dataType.m_field.m_fieldRefName.m_fieldRefType + " = ?";
+				sqlQuery += " AND dr." + dataType.m_field.m_fieldRefName.m_fieldRefName + " = ?";
+			}
+		}
+	}
+
+	// Dimension filters on debit side (manually prefixed with dr. for self-join)
+	for (auto& filter : selFilter) {
+		ibValueMetaObjectAttributeBase::ibSQLField sqlDim = ibValueMetaObjectAttributeBase::GetSQLFieldData(filter.first);
+		sqlQuery += " AND dr." + sqlDim.m_fieldTypeName + " = ?";
+		for (auto dataType : sqlDim.m_types) {
+			if (dataType.m_type != ibValueMetaObjectAttributeBase::ibFieldTypes::ibFieldTypes_Reference) {
+				sqlQuery += " AND dr." + dataType.m_field.m_fieldName + " = ?";
+			}
+			else {
+				sqlQuery += " AND dr." + dataType.m_field.m_fieldRefName.m_fieldRefType + " = ?";
+				sqlQuery += " AND dr." + dataType.m_field.m_fieldRefName.m_fieldRefName + " = ?";
+			}
+		}
+	}
+
+	// GROUP BY AccountDr, AccountCr
+	sqlQuery += " GROUP BY ";
+
+	// Group by dr.Account fields
+	{
+		sqlQuery += "dr." + sqlColAccount.m_fieldTypeName;
+		for (auto dataType : sqlColAccount.m_types) {
+			if (dataType.m_type != ibValueMetaObjectAttributeBase::ibFieldTypes::ibFieldTypes_Reference) {
+				sqlQuery += ", dr." + dataType.m_field.m_fieldName;
+			}
+			else {
+				sqlQuery += ", dr." + dataType.m_field.m_fieldRefName.m_fieldRefType;
+				sqlQuery += ", dr." + dataType.m_field.m_fieldRefName.m_fieldRefName;
+			}
+		}
+	}
+
+	// Group by cr.Account fields
+	{
+		sqlQuery += ", cr." + sqlColAccount.m_fieldTypeName;
+		for (auto dataType : sqlColAccount.m_types) {
+			if (dataType.m_type != ibValueMetaObjectAttributeBase::ibFieldTypes::ibFieldTypes_Reference) {
+				sqlQuery += ", cr." + dataType.m_field.m_fieldName;
+			}
+			else {
+				sqlQuery += ", cr." + dataType.m_field.m_fieldRefName.m_fieldRefType;
+				sqlQuery += ", cr." + dataType.m_field.m_fieldRefName.m_fieldRefName;
+			}
+		}
+	}
+
+	// Group by resource type names
+	for (const auto object : m_metaObject->GetResourceArrayObject()) {
+		ibValueMetaObjectAttributeBase::ibSQLField sqlResource = ibValueMetaObjectAttributeBase::GetSQLFieldData(object);
+		sqlQuery += ", dr." + sqlResource.m_fieldTypeName;
+	}
+
+	// HAVING - filter out zero amounts
+	sqlQuery += " HAVING "; bool firstHaving = true;
+
+	for (const auto object : m_metaObject->GetResourceArrayObject()) {
+		wxString orCase = (!firstHaving ? "OR (" : "");
+		wxString orCaseEnd = (!firstHaving ? ")" : "");
+		ibValueMetaObjectAttributeBase::ibSQLField sqlResource = ibValueMetaObjectAttributeBase::GetSQLFieldData(object);
+		sqlQuery += orCase + " CAST(SUM(dr." + sqlResource.m_types[0].m_field.m_fieldName
+			+ ") AS NUMERIC) " + orCaseEnd + " <> 0.0";
+		firstHaving = false;
+	}
+
+	// Prepare and bind parameters
+	ibPreparedStatement* statement = db_query->PrepareStatement(sqlQuery);
+
+	if (statement == nullptr)
+		return retTable;
+
+	int position = 1;
+
+	// dr.Active = true, cr.Active = true
+	ibValueMetaObjectAttributeBase::SetValueAttribute(m_metaObject->GetRegisterActive(), true, statement, position);
+	ibValueMetaObjectAttributeBase::SetValueAttribute(m_metaObject->GetRegisterActive(), true, statement, position);
+
+	// Period range
+	ibValueMetaObjectAttributeBase::SetValueAttribute(m_metaObject->GetRegisterPeriod(), cBeginOfPeriod.GetDate(), statement, position);
+	ibValueMetaObjectAttributeBase::SetValueAttribute(m_metaObject->GetRegisterPeriod(), cEndOfPeriod.GetDate(), statement, position);
+
+	// Account filter
+	if (hasAccountFilter) {
+		ibValueMetaObjectAttributeBase::SetValueAttribute(m_metaObject->GetRegisterAccount(), cAccount, statement, position);
+	}
+
+	// Dimension filters
+	for (auto& filter : selFilter) {
+		ibValueMetaObjectAttributeBase::SetValueAttribute(filter.first, filter.second, statement, position);
+	}
+
+	ibDatabaseResultSet* resultSet = statement->RunQueryWithResults();
+
+	if (resultSet == nullptr)
+		return retTable;
+
+	while (resultSet->Next()) {
+		ibValueModelTable::ibValueModelTableReturnLine* retLine = retTable->GetRowAt(retTable->AppendRow());
+		wxASSERT(retLine);
+
+		// Read AccountDr - aliased to "AccountDr" prefix, compatible with GetValueAttribute(fieldName, metaAttr, ...)
+		{
+			ibValue retVal;
+			if (ibValueMetaObjectAttributeBase::GetValueAttribute(wxT("AccountDr"), m_metaObject->GetRegisterAccount(), retVal, resultSet))
+				retLine->SetAt(wxT("AccountDr"), retVal);
+		}
+
+		// Read AccountCr - aliased to "AccountCr" prefix
+		{
+			ibValue retVal;
+			if (ibValueMetaObjectAttributeBase::GetValueAttribute(wxT("AccountCr"), m_metaObject->GetRegisterAccount(), retVal, resultSet))
+				retLine->SetAt(wxT("AccountCr"), retVal);
+		}
+
+		// Read resource amounts
+		for (const auto object : m_metaObject->GetResourceArrayObject()) {
+			ibValue retVal;
+			if (ibValueMetaObjectAttributeBase::GetValueAttribute(object->GetFieldNameDB() + "_N_Amount_", ibValueMetaObjectAttributeBase::ibFieldTypes_Number, object, retVal, resultSet))
+				retLine->SetAt(object->GetName() + "_Amount", retVal);
+		}
+		wxDELETE(retLine);
+	}
+
+	db_query->CloseResultSet(resultSet);
+	db_query->CloseStatement(statement);
 
 	return retTable;
 }

--- a/src/engine/backend/metaCollection/partial/accountingRegisterMetadata.cpp
+++ b/src/engine/backend/metaCollection/partial/accountingRegisterMetadata.cpp
@@ -299,9 +299,9 @@ bool ibValueMetaObjectAccountingRegister::CreateAndUpdateTableDB(ibMetaDataConfi
 
 bool ibValueMetaObjectAccountingRegister::CreateAndUpdateRegisterTableDB(ibMetaDataConfiguration* srcMetaData, ibValueMetaObject* srcMetaObject, int flags)
 {
-	//TODO: Implement DDL for accounting register table
-	// Uses same pattern as AccumulationRegister::CreateAndUpdateBalancesTableDB
-	// but with Account, RecordType, Subconto1..3 predefined columns
+	// Delegates to the base class which handles all predefined attributes
+	// (LineActive, Period, RecordType, Account, Subconto1-3, Recorder, LineNumber)
+	// via FillArrayObjectByPredefined, plus user-defined dimensions and resources.
 	return ibValueMetaObjectRegisterData::CreateAndUpdateTableDB(srcMetaData, srcMetaObject, flags);
 }
 

--- a/src/engine/backend/metaCollection/partial/accountingRegisterObject.cpp
+++ b/src/engine/backend/metaCollection/partial/accountingRegisterObject.cpp
@@ -4,36 +4,231 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #include "accountingRegister.h"
-#include "backend/metaData.h"
+
 #include "backend/appData.h"
 #include "backend/databaseLayer/databaseLayer.h"
+#include "backend/system/systemManager.h"
 
-//TODO: Implement WriteRecordSet, DeleteRecordSet, SaveVirtualTable, DeleteVirtualTable
-// Following the same pattern as accumulationRegisterObject.cpp
+////////////////////////////////////////////////////////////////////////////////////////////////////
 
-bool ibValueRecordSetObjectAccountingRegister::WriteRecordSet(bool replace, bool clearTable) { return false; }
-bool ibValueRecordSetObjectAccountingRegister::DeleteRecordSet() { return false; }
+bool ibValueRecordSetObjectAccountingRegister::WriteRecordSet(bool replace, bool clearTable)
+{
+	if (!appData->DesignerMode())
+	{
+		if (db_query != nullptr && !db_query->IsOpen())
+			ibBackendCoreException::Error(_("Database is not open!"));
+		else if (db_query == nullptr)
+			ibBackendCoreException::Error(_("Database is not open!"));
+
+		if (!ibBackendException::IsEvalMode())
+		{
+			if (!m_metaObject->AccessRight_Write()) {
+				ibBackendAccessException::Error();
+				return false;
+			}
+
+			ibTransactionGuard db_query_active_transaction = db_query;
+			{
+				db_query_active_transaction.BeginTransaction();
+
+				{
+					ibValue cancel = false;
+					m_procUnit->CallAsProc(wxT("BeforeWrite"), cancel);
+
+					if (cancel.GetBoolean()) {
+						db_query_active_transaction.RollBackTransaction();
+						ibBackendCoreException::Error(_("Failed to write object in db!"));
+						return false;
+					}
+				}
+
+				if (!SaveData(replace, clearTable)) {
+					db_query_active_transaction.RollBackTransaction();
+					ibBackendCoreException::Error(_("Failed to write object in db!"));
+					return false;
+				}
+
+				{
+					ibValue cancel = false;
+					m_procUnit->CallAsProc(wxT("OnWrite"), cancel);
+					if (cancel.GetBoolean()) {
+						db_query_active_transaction.RollBackTransaction();
+						ibBackendCoreException::Error(_("Failed to write object in db!"));
+						return false;
+					}
+				}
+
+				db_query_active_transaction.CommitTransaction();
+			}
+
+			m_objModified = false;
+		}
+	}
+
+	return true;
+}
+
+bool ibValueRecordSetObjectAccountingRegister::DeleteRecordSet()
+{
+	if (!appData->DesignerMode())
+	{
+		if (db_query != nullptr && !db_query->IsOpen())
+			ibBackendCoreException::Error(_("Database is not open!"));
+		else if (db_query == nullptr)
+			ibBackendCoreException::Error(_("Database is not open!"));
+
+		if (!ibBackendException::IsEvalMode())
+		{
+			if (!m_metaObject->AccessRight_Delete()) {
+				ibBackendAccessException::Error();
+				return false;
+			}
+
+			ibTransactionGuard db_query_active_transaction = db_query;
+			{
+				db_query_active_transaction.BeginTransaction();
+
+				{
+					ibValue cancel = false;
+					m_procUnit->CallAsProc(wxT("BeforeWrite"), cancel);
+
+					if (cancel.GetBoolean()) {
+						db_query_active_transaction.RollBackTransaction();
+						ibBackendCoreException::Error(_("Failed to write object in db!"));
+						return false;
+					}
+				}
+
+				if (!DeleteData()) {
+					db_query_active_transaction.RollBackTransaction();
+					ibBackendCoreException::Error(_("Failed to write object in db!"));
+					return false;
+				}
+
+				{
+					ibValue cancel = false;
+					m_procUnit->CallAsProc(wxT("OnWrite"), cancel);
+					if (cancel.GetBoolean()) {
+						db_query_active_transaction.RollBackTransaction();
+						ibBackendCoreException::Error(_("Failed to write object in db!"));
+						return false;
+					}
+				}
+
+				db_query_active_transaction.CommitTransaction();
+			}
+
+			m_objModified = false;
+		}
+	}
+
+	return true;
+}
+
 bool ibValueRecordSetObjectAccountingRegister::SaveVirtualTable() { return true; }
 bool ibValueRecordSetObjectAccountingRegister::DeleteVirtualTable() { return true; }
 
-enum Func { enWrite = 0, enRead, enModified, enClear, enGetMetadata };
+enum func
+{
+	eAdd = 0,
+	eCount,
+	eClear,
+	eLoad,
+	eUnload,
+	eWriteRecordSet,
+	eModifiedRecordSet,
+	eReadRecordSet,
+	eSelectedRecordSet,
+	eGetMetadataRecordSet,
+};
+
+enum prop
+{
+	eThisObject,
+	eFilter
+};
+
+//****************************************************************************
+//*                              Support methods                             *
+//****************************************************************************
 
 void ibValueRecordSetObjectAccountingRegister::PrepareNames() const
 {
-	ibValueRecordSetObject::PrepareNames();
+	m_methodHelper->ClearHelper();
+
+	m_methodHelper->AppendFunc(wxT("Add"), wxT("Add()"));
+	m_methodHelper->AppendFunc(wxT("Count"), wxT("Count()"));
+	m_methodHelper->AppendFunc(wxT("Clear"), wxT("Clear()"));
+	m_methodHelper->AppendFunc(wxT("Write"), 1, wxT("Write(replace : boolean)"));
+	m_methodHelper->AppendFunc(wxT("Load"), 1, wxT("Load(value: table)"));
+	m_methodHelper->AppendFunc(wxT("Unload"), wxT("Unload()"));
+	m_methodHelper->AppendFunc(wxT("Modified"), wxT("Modified()"));
+	m_methodHelper->AppendFunc(wxT("Read"), wxT("Read()"));
+	m_methodHelper->AppendFunc(wxT("Selected"), wxT("Selected()"));
+	m_methodHelper->AppendFunc(wxT("GetMetadata"), wxT("GetMetadata()"));
+
+	m_methodHelper->AppendProp(wxT("ThisObject"), true, false, prop::eThisObject, wxNOT_FOUND);
+	m_methodHelper->AppendProp(wxT("Filter"), true, false, prop::eFilter, wxNOT_FOUND);
 }
 
 bool ibValueRecordSetObjectAccountingRegister::SetPropVal(const long lPropNum, const ibValue& varPropVal)
 {
-	return ibValueRecordSetObject::SetPropVal(lPropNum, varPropVal);
+	return false;
 }
 
 bool ibValueRecordSetObjectAccountingRegister::GetPropVal(const long lPropNum, ibValue& pvarPropVal)
 {
-	return ibValueRecordSetObject::GetPropVal(lPropNum, pvarPropVal);
+	switch (lPropNum)
+	{
+	case prop::eThisObject:
+		pvarPropVal = this;
+		return true;
+	case prop::eFilter:
+		pvarPropVal = m_recordSetKeyValue;
+		return true;
+	}
+
+	return false;
 }
 
 bool ibValueRecordSetObjectAccountingRegister::CallAsFunc(const long lMethodNum, ibValue& pvarRetValue, ibValue** paParams, const long lSizeArray)
 {
-	return ibValueRecordSetObject::CallAsFunc(lMethodNum, pvarRetValue, paParams, lSizeArray);
+	switch (lMethodNum)
+	{
+	case func::eAdd:
+		pvarRetValue = ibValue::CreateAndPrepareValueRef<ibValueRecordSetObjectRegisterReturnLine>(this, GetItem(AppendRow()));
+		return true;
+	case func::eCount:
+		pvarRetValue = (unsigned int)GetRowCount();
+		return true;
+	case func::eClear:
+		ibValueModelTableBase::Clear();
+		return true;
+	case func::eLoad:
+		LoadDataFromTable(paParams[0]->ConvertToType<ibValueModelTableBase>());
+		return true;
+	case func::eUnload:
+		pvarRetValue = SaveDataToTable();
+		return true;
+	case func::eWriteRecordSet:
+		WriteRecordSet(
+			lSizeArray > 0 ?
+			paParams[0]->GetBoolean() : true
+		);
+		return true;
+	case func::eModifiedRecordSet:
+		pvarRetValue = m_objModified;
+		return true;
+	case func::eReadRecordSet:
+		Read();
+		return true;
+	case func::eSelectedRecordSet:
+		pvarRetValue = Selected();
+		return true;
+	case func::eGetMetadataRecordSet:
+		pvarRetValue = GetMetaObject();
+		return true;
+	}
+
+	return false;
 }


### PR DESCRIPTION
## Summary

Removes all stubs and TODOs from accounting register.

### DrCrTurnovers (accountingRegisterManager_impl.cpp)
Full SQL with self-join for debit×credit account pairs (корреспонденция).
AccountDr/AccountCr columns with table aliases, filter support, HAVING clause.

### WriteRecordSet/DeleteRecordSet (accountingRegisterObject.cpp)
Full implementation: transaction guard, BeforeWrite/OnWrite events, cancel support, access rights check.

### Object methods (accountingRegisterObject.cpp)
Full PrepareNames: Add, Count, Clear, Write, Load, Unload, Modified, Read, Selected, GetMetadata.
Full SetPropVal/GetPropVal/CallAsFunc.

### DDL (accountingRegisterMetadata.cpp)
Removed TODO — base class handles all predefined attributes via FillArrayObjectByPredefined().