### PR TITLE
The web runtime builds outside MSBuild, and three ways a failure had of saying nothing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,12 @@ endforeach()
 
 option(BUILD_TESTING       "Build unit tests (Google Test)"     OFF)
 
+# The web pair — wfrontend (the OES_USE_WEB frontend) and wenterprise-server.
+# Off by default: until the three CI toolchains have all built them, the desktop
+# suite is what `cmake -B build` is expected to produce, and a web source that
+# stops compiling somewhere must not be able to take that down with it.
+option(OES_BUILD_WEB       "Build the web runtime (wfrontend + wenterprise-server)" OFF)
+
 option(OES_USE_FIREBIRD    "Enable Firebird database driver"    OFF)
 option(OES_USE_POSTGRESQL  "Enable PostgreSQL database driver"  OFF)
 option(OES_USE_ODBC        "Enable ODBC database driver"        OFF)
@@ -463,6 +469,8 @@ endif()
 #   launcher      — executable      (GUI subsystem)
 #   codeRunner    — executable      (GUI subsystem)
 #   simplePlugin  — SHARED library  (plugin example)
+#   wfrontend     — SHARED library  (the web frontend, OES_BUILD_WEB)
+#   wenterprise-server — executable (the web HTTP server, OES_BUILD_WEB)
 # ---------------------------------------------------------------------------
 
 add_subdirectory("${OES_ENGINE_DIR}/backend")
@@ -473,6 +481,10 @@ add_subdirectory("${OES_ENGINE_DIR}/designer")
 add_subdirectory("${OES_ENGINE_DIR}/launcher")
 add_subdirectory("${OES_ENGINE_DIR}/codeRunner")
 add_subdirectory("${OES_ENGINE_DIR}/simplePlugin")
+
+if(OES_BUILD_WEB)
+    add_subdirectory("${OES_ENGINE_DIR}/wenterprise-server")
+endif()
 
 # ---------------------------------------------------------------------------
 # Unit tests (Google Test)

--- a/src/engine/backend/databaseLayer/firebird/firebirdDatabaseLayer.cpp
+++ b/src/engine/backend/databaseLayer/firebird/firebirdDatabaseLayer.cpp
@@ -1822,6 +1822,17 @@ wxString ibDatabaseLayerFirebird::TranslateErrorCodeToString(ibInterfaceFirebird
 		pInterface->GetIscSqlInterprete()(nCode, szError, sizeof(szError));
 		wxCharBuffer systemEncoding = wxLocale::GetSystemEncodingName().mb_str();
 		strReturn = ibDatabaseStringConverter::ConvertFromUnicodeStream(szError, (const char*)systemEncoding);
+
+		// ...and then the status vector, for the same reason the branch above reads
+		// it. The sentence for the CODE is generic by construction -- "a system
+		// error that precludes successful execution of subsequent statements" is
+		// what every system-level failure says -- and WHICH system error it was is
+		// only in the vector. Reading one and not the other is why a lock directory
+		// the process cannot write, a security database it cannot reach and a file
+		// it has no permission on all arrived as one indistinguishable line.
+		long* pVector = (long*)status;
+		while (pInterface->GetFbInterpret()(szError, 512, (const ISC_STATUS**)&pVector))
+			strReturn += wxString::Format(wxT("\n%s"), szError);
 	}
 
 	return strReturn;

--- a/src/engine/frontend/CMakeLists.txt
+++ b/src/engine/frontend/CMakeLists.txt
@@ -102,3 +102,146 @@ set_target_properties(frontend PROPERTIES
     POSITION_INDEPENDENT_CODE ON
     OUTPUT_NAME "frontend"
 )
+
+# =============================================================================
+# wfrontend — the web variant of the frontend
+#
+# The same visual-view / control / form / docView sources as the desktop
+# frontend, compiled with OES_USE_WEB: no native widget is created, the web/
+# layer stands in for the platform one, and what a control would have drawn is
+# reported as JSON instead. Linked by wenterprise-server.
+#
+# The list is HAND-PICKED and mirrors wfrontend.vcxproj — the MSBuild project is
+# the one that has to agree with it, and a GLOB here would silently pull in the
+# 400-odd desktop sources that do not compile in web mode.
+# =============================================================================
+
+if(OES_BUILD_WEB)
+
+set(WFRONTEND_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/wfrontend.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/web/webClient.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/web/webSession.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/web/webApplication.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/web/webFrame.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/web/webWindow.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/web/webSizer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/web/webTimer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/web/webChildFrame.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/visualHost.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/visualHostEvent.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/visualHostClient.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/visualHostClientDocView.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/controlEnum.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/docView/docManager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/docView/docView.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/control.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/controlProperty.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/typeControl.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/window.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/frame.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/sizer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/boxsizer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/button.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/button_res.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/buttonEvent.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/statictext.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/statictextEvent.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/statictext_res.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/textctrl.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/textctrlEvent.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/textctrlProperty.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/textctrl_res.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/checkbox.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/checkboxEvent.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/checkboxProperty.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/checkbox_res.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/layers/commandBar.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/layers/commandReceiver.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/layerObject.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/toolBar.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/toolBar_res.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/toolBarItem.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/toolBarItem_res.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/toolBarEvent.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/toolBarProperty.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/toolBarMenu.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/toolBarAction.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/toolBarItemAction.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/tableBox.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/tableBox_res.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/tableBoxColumn.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/tableBoxColumn_res.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/tableBoxColumnGroup.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/tableBoxColumnGroup_res.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/wrapsizer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/staticboxsizer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/gridsizer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/itemsizer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/form.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/formAttribute.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/formAttributeProperty.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/formCommand.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/formControl.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/settings/formSettings.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/formObject.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/formVisualHost.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/frameEvent.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/frameID.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/frameProperty.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/formAction.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/formFactory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/formMem.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/form_res.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/boxsizer_res.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/gridsizer_res.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/staticboxsizer_res.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/visualView/ctrl/wrapsizer_res.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/web/webStubs.cpp
+)
+
+add_library(wfrontend SHARED ${WFRONTEND_SOURCES})
+
+target_include_directories(wfrontend
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_SOURCE_DIR}/src/engine
+        ${CMAKE_SOURCE_DIR}/src/engine/backend
+)
+
+target_compile_definitions(wfrontend
+    PRIVATE
+        NOPCH
+        OES_USE_WEB
+)
+
+# Same export rule as frontend: WFRONTEND_API is dllexport only while the DLL
+# itself is being built (wfrontend.h).
+if(WIN32)
+    target_compile_definitions(wfrontend PRIVATE WFRONTEND_EXPORTS)
+endif()
+
+target_link_libraries(wfrontend
+    PRIVATE
+        backend
+        wx::core
+        wx::aui
+        wx::html
+        wx::propgrid
+        wx::adv
+        wx::stc
+        wx::xrc
+        wx::qa
+        wx::base
+        wx::net
+        wx::xml
+)
+
+set_target_properties(wfrontend PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+    POSITION_INDEPENDENT_CODE ON
+    OUTPUT_NAME "wfrontend"
+)
+
+endif()

--- a/src/engine/frontend/web/webSizer.h
+++ b/src/engine/frontend/web/webSizer.h
@@ -22,17 +22,24 @@
 
 class ibWebWindow;
 
+// Per-child layout hints. Mirrors wxSizer::Add(proportion, flag,
+// border). "flag" is a bitmask of wxEXPAND / wxLEFT / wxRIGHT /
+// wxUP / wxDOWN / wxStretch (wxSHRINK, wxGROW, wxALIGN_*).
+// Populated from ibValueSizerItem for each added child.
+//
+// It sits outside ibWebSizer because Add() below defaults its parameter to
+// `{}`: a default argument is parsed inside the class, where a nested type's
+// own default member initializers are not yet usable. MSVC accepts it, Clang
+// does not.
+struct ibWebSizerAddParams {
+	int proportion = 0;
+	int flag       = 0;
+	int border     = 0;
+};
+
 class ibWebSizer : public wxObject {
 public:
-	// Per-child layout hints. Mirrors wxSizer::Add(proportion, flag,
-	// border). "flag" is a bitmask of wxEXPAND / wxLEFT / wxRIGHT /
-	// wxUP / wxDOWN / wxStretch (wxSHRINK, wxGROW, wxALIGN_*).
-	// Populated from ibValueSizerItem for each added child.
-	struct AddParams {
-		int proportion = 0;
-		int flag       = 0;
-		int border     = 0;
-	};
+	using AddParams = ibWebSizerAddParams;
 
 	struct Item {
 		wxObject* child = nullptr;  // ibWebWindow* or ibWebSizer*

--- a/src/engine/frontend/wfrontend.cpp
+++ b/src/engine/frontend/wfrontend.cpp
@@ -556,10 +556,62 @@ ibSessionHolder   g_serverSession;
 std::mutex        g_addrMutex;
 std::string       g_serverAddress;
 
-void RememberError()
+// The whole chain, not only its last link: a base that cannot be opened records
+// the driver's reason and the layer's summary as separate entries, and the
+// driver's is the one that says why.
+//
+// `thrown` is what escaped when it was not an ibBackendException -- those put
+// themselves on the chain, a std::exception does not.
+void RememberError(const wxString& thrown = wxEmptyString)
 {
-	const wxString& msg = ibBackendException::GetLastError();
-	g_lastError = msg.IsEmpty() ? "unknown backend error" : std::string(msg.mb_str(wxConvUTF8));
+	wxString combined;
+	for (const wxString& msg : ibBackendException::DrainLastErrors()) {
+		if (!combined.IsEmpty()) combined += wxT("\n--\n");
+		combined += msg;
+	}
+	if (combined.IsEmpty()) combined = thrown;
+	if (combined.IsEmpty()) combined = ibBackendException::GetLastError();
+
+	if (combined.IsEmpty()) {
+		// Nothing new to say. An earlier step in the same bring-up may already
+		// have recorded the real reason, and a placeholder must not replace it.
+		if (g_lastError.empty())
+			g_lastError = "unknown backend error";
+		return;
+	}
+
+	g_lastError = std::string(combined.mb_str(wxConvUTF8));
+}
+
+// One bring-up step, with every way it can fail turned into `false` plus a
+// description in g_lastError.
+//
+// The bring-up THROWS as well as returning false: a Firebird base that cannot
+// be taken is reported by ibDatabaseLayerFirebird::Open raising, and nothing
+// between there and here caught it. Uncaught it reached std::terminate, so the
+// host died on SIGABRT with an empty console -- while the sentence explaining
+// why sat inside the exception, and the `return false` road that would have
+// printed it was never taken. The desktop clients guard the same two calls the
+// same way (designer/mainApp.cpp, enterprise/mainApp.cpp).
+template <class Step>
+bool RunBringUp(Step&& step)
+{
+	wxString thrown;
+	try {
+		if (step())
+			return true;
+	}
+	catch (const ibBackendException&) {
+		// Its ctor pushed the description onto this thread's chain.
+	}
+	catch (const std::exception& err) {
+		thrown = wxString::FromUTF8(err.what());
+	}
+	catch (...) {
+		thrown = _("an unknown failure");
+	}
+	RememberError(thrown);
+	return false;
 }
 
 } // namespace
@@ -640,14 +692,14 @@ WFRONTEND_API bool wfrontendInitFile(
 		return true;  // idempotent
 
 	EnsurePngHandler();
+	g_lastError.clear();
 
-	if (!appDataCreateFile(ibRunMode::eWEB_RUNTIME_MODE,
-		wxString::FromUTF8(filePath.c_str()),
-		wxString::FromUTF8(locale.c_str())))
-	{
-		RememberError();
+	if (!RunBringUp([&] {
+		return appDataCreateFile(ibRunMode::eWEB_RUNTIME_MODE,
+			wxString::FromUTF8(filePath.c_str()),
+			wxString::FromUTF8(locale.c_str()));
+	}))
 		return false;
-	}
 
 	// Stamp debug flag BEFORE FinishConnect: OnFirstConnect listener
 	// (in appData::WireSessionEvents) reads m_loadMetadataFlags inside
@@ -656,7 +708,7 @@ WFRONTEND_API bool wfrontendInitFile(
 	if (debugEnable)
 		appData->m_loadMetadataFlags = _app_start_create_debug_server_flag;
 
-	if (!FinishConnect(ibUser, ibPassword))
+	if (!RunBringUp([&] { return FinishConnect(ibUser, ibPassword); }))
 		return false;
 
 	g_initialized.store(true);
@@ -679,23 +731,23 @@ WFRONTEND_API bool wfrontendInitServer(
 		return true;
 
 	EnsurePngHandler();
+	g_lastError.clear();
 
-	if (!appDataCreateServer(ibRunMode::eWEB_RUNTIME_MODE,
-		wxString::FromUTF8(server.c_str()),
-		wxString::FromUTF8(port.c_str()),
-		wxString::FromUTF8(user.c_str()),
-		wxString::FromUTF8(password.c_str()),
-		wxString::FromUTF8(database.c_str()),
-		wxString::FromUTF8(locale.c_str())))
-	{
-		RememberError();
+	if (!RunBringUp([&] {
+		return appDataCreateServer(ibRunMode::eWEB_RUNTIME_MODE,
+			wxString::FromUTF8(server.c_str()),
+			wxString::FromUTF8(port.c_str()),
+			wxString::FromUTF8(user.c_str()),
+			wxString::FromUTF8(password.c_str()),
+			wxString::FromUTF8(database.c_str()),
+			wxString::FromUTF8(locale.c_str()));
+	}))
 		return false;
-	}
 
 	if (debugEnable)
 		appData->m_loadMetadataFlags = _app_start_create_debug_server_flag;
 
-	if (!FinishConnect(ibUser, ibPassword))
+	if (!RunBringUp([&] { return FinishConnect(ibUser, ibPassword); }))
 		return false;
 
 	g_initialized.store(true);

--- a/src/engine/wenterprise-server/CMakeLists.txt
+++ b/src/engine/wenterprise-server/CMakeLists.txt
@@ -1,0 +1,46 @@
+# =============================================================================
+# OES Enterprise — wenterprise-server (wes)
+#
+# The HTTP server the web client talks to: one translation unit plus the
+# header-only cpp-httplib, over wfrontend (the OES_USE_WEB frontend).
+# =============================================================================
+
+add_executable(wenterprise-server main.cpp)
+
+target_compile_definitions(wenterprise-server
+    PRIVATE
+        NOPCH
+        OES_USE_WEB
+)
+
+target_include_directories(wenterprise-server
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_SOURCE_DIR}/src/engine
+        ${CMAKE_SOURCE_DIR}/src/engine/backend
+        ${CMAKE_SOURCE_DIR}/src/engine/frontend
+)
+
+target_link_libraries(wenterprise-server
+    PRIVATE
+        wfrontend
+        backend
+        wx::base
+        wx::net
+        wx::xml
+)
+
+# cpp-httplib's sockets; the console subsystem so the banner and the shutdown
+# lines have somewhere to go.
+if(WIN32)
+    target_link_libraries(wenterprise-server PRIVATE ws2_32 crypt32)
+    set_target_properties(wenterprise-server PROPERTIES WIN32_EXECUTABLE FALSE)
+endif()
+
+find_package(Threads REQUIRED)
+target_link_libraries(wenterprise-server PRIVATE Threads::Threads)
+
+set_target_properties(wenterprise-server PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)


### PR DESCRIPTION
`wfrontend` and `wenterprise-server` existed only in the MSBuild solution, so on the two platforms that build through CMake the web runtime could not be produced at all — not untested, unbuildable. This gives them CMake targets and fixes the three defects that stood between "it compiles" and "it serves a page".

The server now runs on macOS arm64 (AppleClang 21) against a file base: it serves the client, `/menu` comes back with the configuration's catalogs and documents, and `/admin/diag` answers.

### What is here

**CMake targets for the web pair** (#94). `wfrontend` lists the same 79 sources as `wfrontend.vcxproj` — hand-picked rather than globbed, since a glob would pull in the 400-odd desktop sources that do not compile in web mode — and `wenterprise-server` is `main.cpp` plus header-only cpp-httplib over it.

Both sit behind **`OES_BUILD_WEB`, default OFF**. That is deliberate and worth a review opinion: until a CI job builds them on all three toolchains, `cmake -B build` should keep producing exactly the desktop suite it produces today, and a web source that stops compiling must not be able to take that down. Flipping the default to ON is the right end state once CI covers it.

**`ibWebSizer::AddParams` moved to namespace scope** (#95). It was a nested aggregate used as a `= {}` default argument — MSVC accepts that, Clang correctly refuses, since a default argument is parsed where the enclosing class is still incomplete. The member name stays as an alias, so no callsite moved. This is the first thing that stops a non-MSVC compiler in the web sources, and would equally stop the GCC job the day a Linux web build is attempted.

**The web bring-up now catches** (#96). `ibDatabaseLayerFirebird::Open` reports a base it cannot take by raising, and nothing between there and `main` caught it: a base that could not be opened killed the process on SIGABRT with an empty console, while the sentence explaining why sat inside the exception and `main`'s "Failed to open the database: …" was never reached. Both init functions now run each step through one guard — the same one `designer/mainApp.cpp` and `enterprise/mainApp.cpp` have carried since they learned it the same way — and the error read back is the whole chain rather than its last link.

**The Firebird driver reads the status vector for system errors too** (#97). Below SQLCODE -900 it rendered the code and stopped, so every system-level failure arrived as one indistinguishable sentence. The system branch now walks the vector like the SQL branch above it. Same base, same environment:

```
 Failed to open the database: Unsuccessful execution caused by a system error that precludes successful execution of subsequent statements
+operating system directive access failed
+Permission denied
+/tmp/firebird/
```

### Not here

**#98 stays open.** On macOS the platform sets no Firebird lock directory of its own — `ibFirebirdBootstrap` knows only the vendored Windows `_fb/` layout — so the embedded engine falls back to `/tmp/firebird`, which a framework install leaves owned by the `firebird` account. Running the web server today still needs `FIREBIRD` / `FIREBIRD_LOCK` set by hand. Fixing it means choosing a policy for where a per-user lock directory lives, which is a decision rather than a patch.

### Verification

- Full CMake build, every target, AppleClang 21 / macOS arm64: clean, exit 0.
- `ctest`: exit 0, no failures out of 1842. Not run: the `DISABLED` benchmarks and the groups needing a live server (`FirebirdBatchInsert.*`, `PostgresDialect.*`).
- `wenterprise-server --file=<base> --port=8088` against a real configuration: client served (105 KB), `/menu` returns its catalogs and documents, `/admin/diag` answers, alongside a designer already open on the same base.

Nothing in the MSBuild solution changed, so the Windows web build is untouched.

Closes #94, #95, #96, #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
